### PR TITLE
✨ add gcp bootstrap module

### DIFF
--- a/gcp/bootstrap/README.md
+++ b/gcp/bootstrap/README.md
@@ -35,7 +35,7 @@ module "bootstrap" {
   # https://cloud.google.com/kms/docs/locations
   kms_location                      = "us"
   # Key used to encrypt tfstate bucket
-  key_rotation_days                 = 30
+  kms_key_rotation_days                 = 30
   # This rotation is done by terraform, so if you want to automate this, you should run the bootstrap regularly
   service_account_key_rotation_days = 30
   
@@ -96,7 +96,7 @@ No Modules.
 | backend\_local\_path                  | Local path to create terraform backend configuration file                                              | `string`       | n/a     |   yes    |
 | backend\_location                     | Terraform backend GCS bucket (use one documented here https://cloud.google.com/storage/docs/locations) | `string`       | `"US"`  |    no    |
 | backend\_name                         | Terraform backend GCS bucket name                                                                      | `string`       | n/a     |   yes    |
-| key\_rotation\_days                   | Number of days to set automatic encryption key rotation for bucket                                     | `number`       | `15`    |    no    |
+| kms\_key\_rotation\_days                   | Number of days to set automatic encryption key rotation for bucket                                     | `number`       | `15`    |    no    |
 | kms\_location                         | Terraform keyring location (use one documented here https://cloud.google.com/kms/docs/locations)       | `string`       | `"us"`  |    no    |
 | project\_id                           | The ID of the project where this VPC will be created                                                   | `string`       | n/a     |   yes    |
 | labels                                | Map of labels to put in resources                                                                      | `map(string)`  | `{}`    |    no    |

--- a/gcp/bootstrap/README.md
+++ b/gcp/bootstrap/README.md
@@ -43,6 +43,10 @@ module "bootstrap" {
   tfstate_path       = "myawesomeapp"
   # Where to generate the backend.tf file
   backend_local_path = abspath(path.root)
+
+  labels = {
+    "my-label" = "my-value"
+  }
 }
 ```
 
@@ -95,6 +99,7 @@ No Modules.
 | key\_rotation\_days                   | Number of days to set automatic encryption key rotation for bucket                                     | `number`       | `15`    |    no    |
 | kms\_location                         | Terraform keyring location (use one documented here https://cloud.google.com/kms/docs/locations)       | `string`       | `"us"`  |    no    |
 | project\_id                           | The ID of the project where this VPC will be created                                                   | `string`       | n/a     |   yes    |
+| labels                                | Map of labels to put in resources                                                                      | `map(string)`  | `{}`    |    no    |
 | service\_account\_id                  | Service account ID to manage tfstate and provide Terraform access to orchestrate resources             | `string`       | n/a     |   yes    |
 | service\_account\_key\_rotation\_days | Number of days to set automatic key rotation for service account                                       | `number`       | `30`    |    no    |
 | service\_account\_roles               | Service account roles (gcloud iam roles list)                                                          | `list(string)` | n/a     |   yes    |

--- a/gcp/bootstrap/README.md
+++ b/gcp/bootstrap/README.md
@@ -1,0 +1,111 @@
+# GCP Terraform Bootstrap
+
+This module is an all-in-one bootstrap for Google Cloud Platform Terraform projects. It provides:
+
+- A Google Cloud Storage bucket with symmetric encryption keys stored in KMS with the properly rotation settings
+- IAM auditing configuration
+- A Service Account to be used for by Terraform to create other resources like VPC, GKE clusters and etc (also with automatic private key rotation settings)
+- And an extra sugar: it creates the `backend.tf` file where you need to put your main module
+
+This module must be executed with an user account to provision the bootstrap resources.
+
+## Usage Example
+
+```hcl
+module "bootstrap" {
+  source = "git::ssh://git@github.com:GrooveCommunity/tf-modules.git//gcp/bootstrap?ref=main"
+  
+  # gcloud projects list
+  # Get the "PROJECT_ID" column value
+  project_id = "upper-blueprint"
+  
+  # https://cloud.google.com/storage/docs/locations
+  backend_location = "US"
+  backend_name     = "myawesomeapp-tfstate"
+
+  service_account_id = "myawesomeapp-terraform"
+  # Roles to bind to service account (gcloud iam roles list)
+  service_account_roles = [
+    "roles/compute.networkAdmin",
+    "roles/compute.admin",
+    "roles/container.clusterAdmin",
+  ]
+  
+  # Must be in the available for the same location of the bucket
+  # https://cloud.google.com/kms/docs/locations
+  kms_location                      = "us"
+  # Key used to encrypt tfstate bucket
+  key_rotation_days                 = 30
+  # This rotation is done by terraform, so if you want to automate this, you should run the bootstrap regularly
+  service_account_key_rotation_days = 30
+  
+  # The full path will be gs://${var.backend_name}/terraform/state/${var.tfstate_path}
+  tfstate_path       = "myawesomeapp"
+  # Where to generate the backend.tf file
+  backend_local_path = abspath(path.root)
+}
+```
+
+## Requirements
+
+| Name        | Version   |
+| ----------- | --------- |
+| terraform   | >= 0.13.0 |
+| google      | ~> 3.45   |
+| google-beta | ~> 3.45   |
+
+## Providers
+
+| Name   | Version |
+| ------ | ------- |
+| google | ~> 3.45 |
+| local  | n/a     |
+| time   | n/a     |
+
+## Modules
+
+No Modules.
+
+## Resources
+
+| Name                                                                                                                                         |
+| -------------------------------------------------------------------------------------------------------------------------------------------- |
+| [google_kms_crypto_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key)                       |
+| [google_kms_crypto_key_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) |
+| [google_kms_key_ring](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring)                           |
+| [google_project](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/project)                                  |
+| [google_project_iam_audit_config](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_audit_config)   |
+| [google_project_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_iam_member)               |
+| [google_project_service](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/project_service)                     |
+| [google_service_account](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account)                     |
+| [google_service_account_key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account_key)             |
+| [google_storage_bucket](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket)                       |
+| [google_storage_bucket_iam_member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) |
+| [google_storage_bucket_object](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_object)         |
+| [local_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file)                                             |
+| [time_rotating](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/rotating)                                       |
+
+## Inputs
+
+| Name                                  | Description                                                                                            | Type           | Default | Required |
+| ------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------- | ------- | :------: |
+| backend\_local\_path                  | Local path to create terraform backend configuration file                                              | `string`       | n/a     |   yes    |
+| backend\_location                     | Terraform backend GCS bucket (use one documented here https://cloud.google.com/storage/docs/locations) | `string`       | `"US"`  |    no    |
+| backend\_name                         | Terraform backend GCS bucket name                                                                      | `string`       | n/a     |   yes    |
+| key\_rotation\_days                   | Number of days to set automatic encryption key rotation for bucket                                     | `number`       | `15`    |    no    |
+| kms\_location                         | Terraform keyring location (use one documented here https://cloud.google.com/kms/docs/locations)       | `string`       | `"us"`  |    no    |
+| project\_id                           | The ID of the project where this VPC will be created                                                   | `string`       | n/a     |   yes    |
+| service\_account\_id                  | Service account ID to manage tfstate and provide Terraform access to orchestrate resources             | `string`       | n/a     |   yes    |
+| service\_account\_key\_rotation\_days | Number of days to set automatic key rotation for service account                                       | `number`       | `30`    |    no    |
+| service\_account\_roles               | Service account roles (gcloud iam roles list)                                                          | `list(string)` | n/a     |   yes    |
+| tfstate\_path                         | Remote path on GCS bucket to put terraform tfstate with remote backend                                 | `string`       | n/a     |   yes    |
+
+## Outputs
+
+| Name                          | Description                                                                                                                                                                 |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| keyring                       | KMS keyring used to store tfstate bucket encryption key                                                                                                                     |
+| service\_account              | Service Account to be used by terraform                                                                                                                                     |
+| service\_account\_key         | Service Account key to be used as Google credential to orchestrate infrastructure                                                                                           |
+| service\_account\_key\_object | This module saves the newly created service account key in the bucket used to store the tfstate, so this output value is a reference to the object storing json-encoded key |
+| tfstate\_bucket               | Bucket created to be Terraform's backend                                                                                                                                    |

--- a/gcp/bootstrap/main.tf
+++ b/gcp/bootstrap/main.tf
@@ -44,6 +44,8 @@ resource "google_kms_crypto_key" "bucket_crypto_key" {
   lifecycle {
     prevent_destroy = true
   }
+
+  labels = var.labels
 }
 
 resource "google_kms_crypto_key_iam_member" "bucket_crypto_key" {
@@ -69,6 +71,8 @@ resource "google_storage_bucket" "terraform_backend" {
   }
 
   storage_class = "STANDARD"
+
+  labels = var.labels
 
   depends_on = [
     google_project_service.service,

--- a/gcp/bootstrap/main.tf
+++ b/gcp/bootstrap/main.tf
@@ -1,0 +1,133 @@
+locals {
+  apis_to_enable = toset([
+    "storage-component.googleapis.com",
+    "storage-api.googleapis.com",
+    "cloudkms.googleapis.com",
+  ])
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+resource "google_project_service" "service" {
+  for_each = local.apis_to_enable
+  project  = var.project_id
+  service  = each.value
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+  }
+
+  disable_dependent_services = false
+  disable_on_destroy         = false
+}
+
+resource "google_kms_key_ring" "keyring" {
+  project  = var.project_id
+  name     = var.backend_name
+  location = var.kms_location
+}
+
+resource "google_kms_crypto_key" "bucket_crypto_key" {
+  name            = "${var.backend_name}-gcs-key"
+  key_ring        = google_kms_key_ring.keyring.id
+  rotation_period = "${var.key_rotation_days * 86400}s"
+  purpose         = "ENCRYPT_DECRYPT"
+
+  version_template {
+    algorithm        = "GOOGLE_SYMMETRIC_ENCRYPTION"
+    protection_level = "SOFTWARE"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_kms_crypto_key_iam_member" "bucket_crypto_key" {
+  crypto_key_id = google_kms_crypto_key.bucket_crypto_key.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
+}
+
+resource "google_storage_bucket" "terraform_backend" {
+  project  = var.project_id
+  name     = var.backend_name
+  location = var.backend_location
+
+  force_destroy               = false
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.bucket_crypto_key.id
+  }
+
+  storage_class = "STANDARD"
+
+  depends_on = [
+    google_project_service.service,
+    google_kms_crypto_key_iam_member.bucket_crypto_key,
+  ]
+}
+
+resource "google_storage_bucket_iam_member" "member" {
+  bucket = google_storage_bucket.terraform_backend.name
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.terraform.email}"
+}
+
+resource "google_service_account" "terraform" {
+  project      = var.project_id
+  account_id   = var.service_account_id
+  display_name = "Terraform (${var.service_account_id})"
+}
+
+resource "time_rotating" "service_account_rotation" {
+  rotation_days = var.service_account_key_rotation_days
+}
+
+resource "google_service_account_key" "service_account_key" {
+  service_account_id = google_service_account.terraform.name
+  key_algorithm      = "KEY_ALG_RSA_2048"
+  public_key_type    = "TYPE_X509_PEM_FILE"
+  private_key_type   = "TYPE_GOOGLE_CREDENTIALS_FILE"
+}
+
+resource "google_project_iam_member" "service_account_role" {
+  for_each = toset(var.service_account_roles)
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.terraform.email}"
+}
+
+
+resource "google_project_iam_audit_config" "project" {
+  project = var.project_id
+  service = "allServices"
+  audit_log_config {
+    log_type = "ADMIN_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_READ"
+  }
+  audit_log_config {
+    log_type = "DATA_WRITE"
+  }
+}
+
+resource "google_storage_bucket_object" "service_account_key" {
+  name    = "terraform/keys/${var.service_account_id}"
+  content = base64decode(google_service_account_key.service_account_key.private_key)
+  bucket  = google_storage_bucket.terraform_backend.name
+}
+
+resource "local_file" "backend" {
+  content  = templatefile("${path.module}/templates/backend.tpl", { bucket_name : google_storage_bucket.terraform_backend.name, tfstate_path : var.tfstate_path })
+  filename = "${var.backend_local_path}/backend.tf"
+}

--- a/gcp/bootstrap/main.tf
+++ b/gcp/bootstrap/main.tf
@@ -33,7 +33,7 @@ resource "google_kms_key_ring" "keyring" {
 resource "google_kms_crypto_key" "bucket_crypto_key" {
   name            = "${var.backend_name}-gcs-key"
   key_ring        = google_kms_key_ring.keyring.id
-  rotation_period = "${var.key_rotation_days * 86400}s"
+  rotation_period = "${var.kms_key_rotation_days * 86400}s"
   purpose         = "ENCRYPT_DECRYPT"
 
   version_template {

--- a/gcp/bootstrap/outputs.tf
+++ b/gcp/bootstrap/outputs.tf
@@ -1,0 +1,25 @@
+output "keyring" {
+  description = "KMS keyring used to store tfstate bucket encryption key"
+  value       = google_kms_key_ring.keyring
+}
+
+output "tfstate_bucket" {
+  description = "Bucket created to be Terraform's backend"
+  value       = google_storage_bucket.terraform_backend
+}
+
+output "service_account" {
+  description = "Service Account to be used by terraform"
+  value       = google_service_account.terraform
+}
+
+output "service_account_key" {
+  description = "Service Account key to be used as Google credential to orchestrate infrastructure"
+  sensitive   = true
+  value       = google_service_account_key.service_account_key
+}
+
+output "service_account_key_object" {
+  description = "This module saves the newly created service account key in the bucket used to store the tfstate, so this output value is a reference to the object storing json-encoded key"
+  value       = google_storage_bucket_object.service_account_key
+}

--- a/gcp/bootstrap/roles.txt
+++ b/gcp/bootstrap/roles.txt
@@ -1,0 +1,4982 @@
+---
+description: Ability to view or act on access approval requests and view configuration
+etag: AA==
+name: roles/accessapproval.approver
+stage: BETA
+title: Access Approval Approver
+---
+description: Ability update the Access Approval configuration
+etag: AA==
+name: roles/accessapproval.configEditor
+stage: BETA
+title: Access Approval Config Editor
+---
+description: Ability to view access approval requests and configuration
+etag: AA==
+name: roles/accessapproval.viewer
+stage: BETA
+title: Access Approval Viewer
+---
+description: Create, edit, and change Cloud access bindings.
+etag: AA==
+name: roles/accesscontextmanager.gcpAccessAdmin
+stage: GA
+title: Cloud Access Binding Admin
+---
+description: Read access to Cloud access bindings.
+etag: AA==
+name: roles/accesscontextmanager.gcpAccessReader
+stage: GA
+title: Cloud Access Binding Reader
+---
+description: Full access to policies, access levels, and access zones
+etag: AA==
+name: roles/accesscontextmanager.policyAdmin
+stage: GA
+title: Access Context Manager Admin
+---
+description: Edit access to policies.  Create, edit, and change access levels and
+  access zones.
+etag: AA==
+name: roles/accesscontextmanager.policyEditor
+stage: GA
+title: Access Context Manager Editor
+---
+description: Read access to policies, access levels, and access zones.
+etag: AA==
+name: roles/accesscontextmanager.policyReader
+stage: GA
+title: Access Context Manager Reader
+---
+etag: AA==
+name: roles/accesscontextmanager.vpcScTroubleshooterViewer
+stage: GA
+title: VPC Service Controls Troubleshooter Viewer
+---
+description: Access to edit and deploy an action
+etag: AA==
+name: roles/actions.Admin
+stage: GA
+title: Actions Admin
+---
+description: Access to view an action
+etag: AA==
+name: roles/actions.Viewer
+stage: GA
+title: Actions Viewer
+---
+description: Grants full access to all resources in Vertex AI
+etag: AA==
+name: roles/aiplatform.admin
+stage: BETA
+title: Vertex AI Administrator
+---
+description: Gives AI Platform Custom Code the proper permissions.
+etag: AA==
+name: roles/aiplatform.customCodeServiceAgent
+stage: GA
+title: AI Platform Custom Code Service Agent
+---
+description: Grants full access to all resources in Vertex AI Feature Store
+etag: AA==
+name: roles/aiplatform.featurestoreAdmin
+stage: BETA
+title: Vertex AI Feature Store Admin
+---
+description: Grants access to use all resources in Vertex AI Feature Store
+etag: AA==
+name: roles/aiplatform.featurestoreUser
+stage: BETA
+title: Vertex AI Feature Store User
+---
+description: Grants access to use migration service in Vertex AI
+etag: AA==
+name: roles/aiplatform.migrator
+stage: BETA
+title: Vertex AI Migration Service User
+---
+description: Gives AI Platform the permissions it needs to function.
+etag: AA==
+name: roles/aiplatform.serviceAgent
+stage: GA
+title: AI Platform Service Agent
+---
+description: Grants access to use all resource in Vertex AI
+etag: AA==
+name: roles/aiplatform.user
+stage: BETA
+title: Vertex AI User
+---
+description: Grants access to view all resource in Vertex AI
+etag: AA==
+name: roles/aiplatform.viewer
+stage: BETA
+title: Vertex AI Viewer
+---
+description: Full access to manage devices.
+etag: AA==
+name: roles/androidmanagement.user
+stage: GA
+title: Android Management User
+---
+description: Gives the Anthos service agent access to Cloud Platformresources.
+etag: AA==
+name: roles/anthos.serviceAgent
+stage: GA
+title: Anthos Service Agent
+---
+description: Gives the Anthos Audit service agent access toCloud Platform resources.
+etag: AA==
+name: roles/anthosaudit.serviceAgent
+stage: GA
+title: Anthos Audit Service Agent
+---
+description: Gives the Anthos Config Management service agent access toCloud Platform
+  resources.
+etag: AA==
+name: roles/anthosconfigmanagement.serviceAgent
+stage: GA
+title: Anthos Config Management Service Agent
+---
+description: Gives the Anthos Identity service agent access toCloud Platform resources.
+etag: AA==
+name: roles/anthosidentityservice.serviceAgent
+stage: GA
+title: Anthos Identity Service Agent
+---
+description: Gives the Anthos Service Mesh service agent access to Cloud Platform
+  resources.
+etag: AA==
+name: roles/anthosservicemesh.serviceAgent
+stage: GA
+title: Anthos Service Mesh Service Agent
+---
+description: Full access to ApiGateway and related resources.
+etag: AA==
+name: roles/apigateway.admin
+stage: GA
+title: ApiGateway Admin
+---
+description: Read-only access to ApiGateway and related resources.
+etag: AA==
+name: roles/apigateway.viewer
+stage: GA
+title: ApiGateway Viewer
+---
+description: Full access to all apigee resource features
+etag: AA==
+name: roles/apigee.admin
+stage: GA
+title: Apigee Organization Admin
+---
+description: Curated set of permissions for Apigee Universal Data Collection Agent
+  to manage analytics for an Apigee Organization
+etag: AA==
+name: roles/apigee.analyticsAgent
+stage: GA
+title: Apigee Analytics Agent
+---
+description: Analytics editor for an Apigee Organization
+etag: AA==
+name: roles/apigee.analyticsEditor
+stage: GA
+title: Apigee Analytics Editor
+---
+description: Analytics viewer for an Apigee Organization
+etag: AA==
+name: roles/apigee.analyticsViewer
+stage: GA
+title: Apigee Analytics Viewer
+---
+description: Full read/write access to all apigee API resources
+etag: AA==
+name: roles/apigee.apiAdmin
+stage: GA
+title: Apigee API Admin
+---
+description: Reader of apigee resources
+etag: AA==
+name: roles/apigee.apiReader
+stage: GA
+title: Apigee API Reader
+---
+description: Developer admin of apigee resources
+etag: AA==
+name: roles/apigee.developerAdmin
+stage: GA
+title: Apigee Developer Admin
+---
+description: Full read/write access to apigee environment resources, including deployments.
+etag: AA==
+name: roles/apigee.environmentAdmin
+stage: GA
+title: Apigee Environment Admin
+---
+description: All permissions related to monetization
+etag: AA==
+name: roles/apigee.monetizationAdmin
+stage: GA
+title: Apigee Monetization Admin
+---
+description: Portal admin for an Apigee Organization
+etag: AA==
+name: roles/apigee.portalAdmin
+stage: GA
+title: Apigee Portal Admin
+---
+description: Viewer of all apigee resources
+etag: AA==
+name: roles/apigee.readOnlyAdmin
+stage: GA
+title: Apigee Read-only Admin
+---
+description: Curated set of permissions for a runtime agent to access Apigee Organization
+  resources
+etag: AA==
+name: roles/apigee.runtimeAgent
+stage: GA
+title: Apigee Runtime Agent
+---
+description: Service agent that grants access to Apigee resources - API Products,
+  Developers, Developer Apps, and App Keys.
+etag: AA==
+name: roles/apigee.serviceAgent
+stage: GA
+title: Apigee Service Agent
+---
+description: Curated set of permissions for a Synchronizer to manage environments
+  in an Apigee Organization
+etag: AA==
+name: roles/apigee.synchronizerManager
+stage: GA
+title: Apigee Synchronizer Manager
+---
+description: Admin of Apigee Connect
+etag: AA==
+name: roles/apigeeconnect.Admin
+stage: GA
+title: Apigee Connect Admin
+---
+description: Ability to set up Apigee Connect agent between external clusters and
+  Google.
+etag: AA==
+name: roles/apigeeconnect.Agent
+stage: GA
+title: Apigee Connect Agent
+---
+description: Give the App Development Experience service agent access toCloud Platform
+  resources.
+etag: AA==
+name: roles/appdevelopmentexperience.serviceAgent
+stage: GA
+title: App Development Experience Service Agent
+---
+description: Full management of App Engine apps (but not storage).
+etag: AA==
+name: roles/appengine.appAdmin
+stage: GA
+title: App Engine Admin
+---
+description: Ability to create the App Engine resource for the project.
+etag: AA==
+name: roles/appengine.appCreator
+stage: GA
+title: App Engine Creator
+---
+description: Ability to view App Engine app status.
+etag: AA==
+name: roles/appengine.appViewer
+stage: GA
+title: App Engine Viewer
+---
+description: Ability to view App Engine app status and deployed source code.
+etag: AA==
+name: roles/appengine.codeViewer
+stage: GA
+title: App Engine Code Viewer
+---
+description: Necessary permissions to deploy new code to App Engine, and remove old
+  versions.
+etag: AA==
+name: roles/appengine.deployer
+stage: GA
+title: App Engine Deployer
+---
+description: Can view and change traffic splits, scaling settings, and delete old
+  versions; can't create new versions.
+etag: AA==
+name: roles/appengine.serviceAdmin
+stage: GA
+title: App Engine Service Admin
+---
+description: Can edit and manage App Engine Flexible Environment apps. Includes access
+  to service accounts.
+etag: AA==
+name: roles/appengineflex.serviceAgent
+stage: GA
+title: App Engine flexible environment Service Agent
+---
+description: Administrator access to create and manage repositories.
+etag: AA==
+name: roles/artifactregistry.admin
+stage: BETA
+title: Artifact Registry Administrator
+---
+description: Access to read repository items.
+etag: AA==
+name: roles/artifactregistry.reader
+stage: BETA
+title: Artifact Registry Reader
+---
+description: Access to manage artifacts in repositories.
+etag: AA==
+name: roles/artifactregistry.repoAdmin
+stage: BETA
+title: Artifact Registry Repository Administrator
+---
+description: Gives the Artifact Registry service account access to managed resources.
+etag: AA==
+name: roles/artifactregistry.serviceAgent
+stage: GA
+title: Artifact Registry Service Agent
+---
+description: Access to read and write repository items.
+etag: AA==
+name: roles/artifactregistry.writer
+stage: BETA
+title: Artifact Registry Writer
+---
+description: Grants full access to Assured Workloads resources, including IAM policy
+  administration.
+etag: AA==
+name: roles/assuredworkloads.admin
+stage: GA
+title: Assured Workloads Administrator
+---
+description: Grants access to read and write to Assured Workloads resources.
+etag: AA==
+name: roles/assuredworkloads.editor
+stage: GA
+title: Assured Workloads Editor
+---
+description: Grants read access to all Assured Workloads resources.
+etag: AA==
+name: roles/assuredworkloads.reader
+stage: GA
+title: Assured Workloads Reader
+---
+description: Gives the Assured Workloads service account access to create KMS keyrings
+  and keys, and to monitor Assured Workloads.
+etag: AA==
+name: roles/assuredworkloads.serviceAgent
+stage: GA
+title: Assured Workloads Service Agent
+---
+description: Full access to all AutoML resources
+etag: AA==
+name: roles/automl.admin
+stage: BETA
+title: AutoML Admin
+---
+description: Editor of all AutoML resources
+etag: AA==
+name: roles/automl.editor
+stage: BETA
+title: AutoML Editor
+---
+description: Predict using models
+etag: AA==
+name: roles/automl.predictor
+stage: BETA
+title: AutoML Predictor
+---
+description: AutoML service agent can act as Cloud Storage admin and export BigQuery
+  tables, which can be backed by Cloud Storage and Cloud Bigtable.
+etag: AA==
+name: roles/automl.serviceAgent
+stage: GA
+title: AutoML Service Agent
+---
+description: Viewer of all AutoML resources
+etag: AA==
+name: roles/automl.viewer
+stage: BETA
+title: AutoML Viewer
+---
+description: Full access to all Recommendations AI resources.
+etag: AA==
+name: roles/automlrecommendations.admin
+stage: BETA
+title: Recommendations AI Admin
+---
+description: Viewer of all Recommendations AI resources.
+etag: AA==
+name: roles/automlrecommendations.adminViewer
+stage: BETA
+title: Recommendations AI Admin Viewer
+---
+description: Editor of all Recommendations AI resources.
+etag: AA==
+name: roles/automlrecommendations.editor
+stage: BETA
+title: Recommendations AI Editor
+---
+description: Recommendations AI service uploads catalog feeds from Cloud Storage,
+  reports results to the customer Cloud Storage bucket, writes logs to customer projects,
+  and writes and reads Stackdriver metrics for customer projects.
+etag: AA==
+name: roles/automlrecommendations.serviceAgent
+stage: GA
+title: Recommendations AI Service Agent
+---
+description: Viewer of all Recommendations AI resources except automlrecommendations.apiKeys.
+  To have all read access use Recommendations AI Admin Viewer role instead.
+etag: AA==
+name: roles/automlrecommendations.viewer
+stage: BETA
+title: Recommendations AI Viewer
+---
+description: Access to write metrics for autoscaling site
+etag: AA==
+name: roles/autoscaling.metricsWriter
+stage: BETA
+title: Autoscaling Metrics Writer
+---
+description: Access to read recommendations from autoscaling site
+etag: AA==
+name: roles/autoscaling.recommendationsReader
+stage: BETA
+title: Autoscaling Recommendations Reader
+---
+description: Full access to all autoscaling site features
+etag: AA==
+name: roles/autoscaling.sitesAdmin
+stage: BETA
+title: Autoscaling Site Admin
+---
+description: Access to write state for autoscaling site
+etag: AA==
+name: roles/autoscaling.stateWriter
+stage: BETA
+title: Autoscaling State Writer
+---
+description: Enable Access Transparency for Organization
+etag: AA==
+name: roles/axt.admin
+stage: GA
+title: Access Transparency Admin
+---
+description: Administer all BigQuery resources and data
+etag: AA==
+name: roles/bigquery.admin
+stage: GA
+title: BigQuery Admin
+---
+etag: AA==
+name: roles/bigquery.connectionAdmin
+stage: GA
+title: BigQuery Connection Admin
+---
+etag: AA==
+name: roles/bigquery.connectionUser
+stage: GA
+title: BigQuery Connection User
+---
+description: Access to edit all the contents of datasets
+etag: AA==
+name: roles/bigquery.dataEditor
+stage: GA
+title: BigQuery Data Editor
+---
+description: Full access to datasets and all of their contents
+etag: AA==
+name: roles/bigquery.dataOwner
+stage: GA
+title: BigQuery Data Owner
+---
+description: Access to view datasets and all of their contents
+etag: AA==
+name: roles/bigquery.dataViewer
+stage: GA
+title: BigQuery Data Viewer
+---
+description: Access to view filtered table data defined by a row access policy
+etag: AA==
+name: roles/bigquery.filteredDataViewer
+stage: GA
+title: BigQuery Filtered Data Viewer
+---
+description: Access to run jobs
+etag: AA==
+name: roles/bigquery.jobUser
+stage: GA
+title: BigQuery Job User
+---
+description: Access to view table and dataset metadata
+etag: AA==
+name: roles/bigquery.metadataViewer
+stage: GA
+title: BigQuery Metadata Viewer
+---
+description: Access to create and use read sessions
+etag: AA==
+name: roles/bigquery.readSessionUser
+stage: GA
+title: BigQuery Read Session User
+---
+description: Administer all BigQuery resources.
+etag: AA==
+name: roles/bigquery.resourceAdmin
+stage: GA
+title: BigQuery Resource Admin
+---
+description: Manage all BigQuery resources, but cannot make purchasing decisions.
+etag: AA==
+name: roles/bigquery.resourceEditor
+stage: GA
+title: BigQuery Resource Editor
+---
+description: View all BigQuery resources but cannot make changes or purchasing decisions.
+etag: AA==
+name: roles/bigquery.resourceViewer
+stage: GA
+title: BigQuery Resource Viewer
+---
+description: When applied to a project, access to run queries, create datasets, read
+  dataset metadata, and list tables. When applied to a dataset, access to read dataset
+  metadata and list tables within the dataset.
+etag: AA==
+name: roles/bigquery.user
+stage: GA
+title: BigQuery User
+---
+description: Gives BigQuery Connection Service access to Cloud SQL instances in user
+  projects.
+etag: AA==
+name: roles/bigqueryconnection.serviceAgent
+stage: GA
+title: BigQuery Connection Service Agent
+---
+description: 'Gives BigQuery Data Transfer Service access to start bigquery jobs in
+  consumer project. '
+etag: AA==
+name: roles/bigquerydatatransfer.serviceAgent
+stage: GA
+title: BigQuery Data Transfer Service Agent
+---
+description: Full access to all Bigtable resources and ability to assign Bigtable
+  IAM roles.
+etag: AA==
+name: roles/bigtable.admin
+stage: GA
+title: Bigtable Administrator
+---
+description: Read access to data in existing tables; read access to metadata for instances,
+  clusters, and tables, including column families.
+etag: AA==
+name: roles/bigtable.reader
+stage: GA
+title: Bigtable Reader
+---
+description: Read and write access to data in existing tables; read access to metadata
+  for instances, clusters, and tables, including column families.
+etag: AA==
+name: roles/bigtable.user
+stage: GA
+title: Bigtable User
+---
+description: Read access to metadata for instances, clusters, and tables, including
+  column families.
+etag: AA==
+name: roles/bigtable.viewer
+stage: GA
+title: Bigtable Viewer
+---
+description: Authorized to see and manage all aspects of billing accounts.
+etag: AA==
+name: roles/billing.admin
+stage: GA
+title: Billing Account Administrator
+---
+description: Can view and export cost information of billing accounts.
+etag: AA==
+name: roles/billing.costsManager
+stage: GA
+title: Billing Account Costs Manager
+---
+description: Creator of billing accounts.
+etag: AA==
+name: roles/billing.creator
+stage: GA
+title: Billing Account Creator
+---
+description: Can assign a project's billing account or disable its billing.
+etag: AA==
+name: roles/billing.projectManager
+stage: GA
+title: Project Billing Manager
+---
+description: Can associate projects with billing accounts
+etag: AA==
+name: roles/billing.user
+stage: GA
+title: Billing Account User
+---
+description: Can view information about billing accounts.
+etag: AA==
+name: roles/billing.viewer
+stage: GA
+title: Billing Account Viewer
+---
+description: Adminstrator of Binary Authorization Attestors
+etag: AA==
+name: roles/binaryauthorization.attestorsAdmin
+stage: GA
+title: Binary Authorization Attestor Admin
+---
+description: Editor of Binary Authorization Attestors
+etag: AA==
+name: roles/binaryauthorization.attestorsEditor
+stage: GA
+title: Binary Authorization Attestor Editor
+---
+description: Caller of Binary Authorization Attestors VerifyImageAttested
+etag: AA==
+name: roles/binaryauthorization.attestorsVerifier
+stage: GA
+title: Binary Authorization Attestor Image Verifier
+---
+description: Viewer of Binary Authorization Attestors
+etag: AA==
+name: roles/binaryauthorization.attestorsViewer
+stage: GA
+title: Binary Authorization Attestor Viewer
+---
+description: Administrator of Binary Authorization Policy
+etag: AA==
+name: roles/binaryauthorization.policyAdmin
+stage: GA
+title: Binary Authorization Policy Administrator
+---
+description: Editor of Binary Authorization Policy
+etag: AA==
+name: roles/binaryauthorization.policyEditor
+stage: GA
+title: Binary Authorization Policy Editor
+---
+description: Viewer of Binary Authorization Policy
+etag: AA==
+name: roles/binaryauthorization.policyViewer
+stage: GA
+title: Binary Authorization Policy Viewer
+---
+description: Can read Notes and Occurrences from the Container Analysis Service to
+  find and verify signatures.
+etag: AA==
+name: roles/binaryauthorization.serviceAgent
+stage: GA
+title: Binary Authorization Service Agent
+---
+description: Access to browse GCP resources.
+etag: AA==
+name: roles/browser
+stage: GA
+title: Browser
+---
+description: Can view and modify bot configurations
+etag: AA==
+name: roles/chat.owner
+stage: GA
+title: Chat Bots Owner
+---
+description: Can view bot configurations
+etag: AA==
+name: roles/chat.reader
+stage: GA
+title: Chat Bots Viewer
+---
+description: Admins can view and modify Chronicle service details.
+etag: AA==
+name: roles/chroniclesm.admin
+stage: GA
+title: Chronicle Service Admin
+---
+description: Viewers can see Chronicle service details but not change them.
+etag: AA==
+name: roles/chroniclesm.viewer
+stage: GA
+title: Chronicle Service Viewer
+---
+description: Full access to cloud assets metadata
+etag: AA==
+name: roles/cloudasset.owner
+stage: GA
+title: Cloud Asset Owner
+---
+description: Gives Cloud Asset service agent permissions to Cloud Storage and BigQuery
+  for exporting Assets, and permission to publish to Cloud Pub/Sub topics for Asset
+  Real Time Feed.
+etag: AA==
+name: roles/cloudasset.serviceAgent
+stage: GA
+title: Cloud Asset Service Agent
+---
+description: Read only access to cloud assets metadata
+etag: AA==
+name: roles/cloudasset.viewer
+stage: GA
+title: Cloud Asset Viewer
+---
+description: Can perform builds
+etag: AA==
+name: roles/cloudbuild.builds.builder
+stage: GA
+title: Cloud Build Service Account
+---
+description: Can create and cancel builds
+etag: AA==
+name: roles/cloudbuild.builds.editor
+stage: GA
+title: Cloud Build Editor
+---
+description: Can view builds
+etag: AA==
+name: roles/cloudbuild.builds.viewer
+stage: GA
+title: Cloud Build Viewer
+---
+description: Gives Cloud Build service account access to managed resources.
+etag: AA==
+name: roles/cloudbuild.serviceAgent
+stage: GA
+title: Cloud Build Service Agent
+---
+description: Full access to Firebase Remote Config resources.
+etag: AA==
+name: roles/cloudconfig.admin
+stage: GA
+title: Firebase Remote Config Admin
+---
+description: Read access to Firebase Remote Config resources.
+etag: AA==
+name: roles/cloudconfig.viewer
+stage: GA
+title: Firebase Remote Config Viewer
+---
+description: Cloud Debugger agents are allowed to register and provide debug snapshot
+  data.
+etag: AA==
+name: roles/clouddebugger.agent
+stage: BETA
+title: Cloud Debugger Agent
+---
+description: User Access to Cloud Debugger.  Can create, delete and view snapshots
+  and logpoints.
+etag: AA==
+name: roles/clouddebugger.user
+stage: BETA
+title: Cloud Debugger User
+---
+description: Gives Cloud Deploy Service Account access to managed resources.
+etag: AA==
+name: roles/clouddeploy.serviceAgent
+stage: GA
+title: Cloud Deploy Service Agent
+---
+description: Full access to functions, operations and locations.
+etag: AA==
+name: roles/cloudfunctions.admin
+stage: GA
+title: Cloud Functions Admin
+---
+description: Read and write access to all functions-related resources.
+etag: AA==
+name: roles/cloudfunctions.developer
+stage: GA
+title: Cloud Functions Developer
+---
+description: Ability to invoke HTTP functions with restricted access.
+etag: AA==
+name: roles/cloudfunctions.invoker
+stage: GA
+title: Cloud Functions Invoker
+---
+description: Gives Cloud Functions service account access to managed resources.
+etag: AA==
+name: roles/cloudfunctions.serviceAgent
+stage: GA
+title: Cloud Functions Service Agent
+---
+description: Read-only access to functions and locations.
+etag: AA==
+name: roles/cloudfunctions.viewer
+stage: GA
+title: Cloud Functions Viewer
+---
+description: Full control of all Cloud IoT resources and permissions.
+etag: AA==
+name: roles/cloudiot.admin
+stage: GA
+title: Cloud IoT Admin
+---
+description: Access to update the device configuration, but not to create or delete
+  devices.
+etag: AA==
+name: roles/cloudiot.deviceController
+stage: GA
+title: Cloud IoT Device Controller
+---
+description: Read-write access to all Cloud IoT resources.
+etag: AA==
+name: roles/cloudiot.editor
+stage: GA
+title: Cloud IoT Editor
+---
+description: Access to create and delete devices from registries, but not to modify
+  the registries, and enable devices to publish to topics associated with IoT registry.
+etag: AA==
+name: roles/cloudiot.provisioner
+stage: GA
+title: Cloud IoT Provisioner
+---
+description: 'Grants the ability to manage Cloud IoT Core resources, including publishing
+  data to Cloud Pub/Sub and writing device activity logs to Stackdriver. Warning:
+  If this role is removed from the Cloud IoT service account, Cloud IoT Core will
+  be unable to publish data or write device activity logs.'
+etag: AA==
+name: roles/cloudiot.serviceAgent
+stage: GA
+title: Cloud IoT Core Service Agent
+---
+description: Read-only access to all Cloud IoT resources.
+etag: AA==
+name: roles/cloudiot.viewer
+stage: GA
+title: Cloud IoT Viewer
+---
+description: Access to Cloud Talent Solution Self-Service Tools.
+etag: AA==
+name: roles/cloudjobdiscovery.admin
+stage: GA
+title: Admin
+---
+description: Write access to all job data in Cloud Talent Solution.
+etag: AA==
+name: roles/cloudjobdiscovery.jobsEditor
+stage: GA
+title: Job Editor
+---
+description: Read access to all job data in Cloud Talent Solution.
+etag: AA==
+name: roles/cloudjobdiscovery.jobsViewer
+stage: GA
+title: Job Viewer
+---
+description: Write access to all profile data in Cloud Talent Solution.
+etag: AA==
+name: roles/cloudjobdiscovery.profilesEditor
+stage: GA
+title: Profile Editor
+---
+description: Read access to all profile data in Cloud Talent Solution.
+etag: AA==
+name: roles/cloudjobdiscovery.profilesViewer
+stage: GA
+title: Profile Viewer
+---
+description: Enables management of crypto resources.
+etag: AA==
+name: roles/cloudkms.admin
+stage: GA
+title: Cloud KMS Admin
+---
+description: Enables Decrypt operations
+etag: AA==
+name: roles/cloudkms.cryptoKeyDecrypter
+stage: GA
+title: Cloud KMS CryptoKey Decrypter
+---
+description: Enables Encrypt operations
+etag: AA==
+name: roles/cloudkms.cryptoKeyEncrypter
+stage: GA
+title: Cloud KMS CryptoKey Encrypter
+---
+description: Enables Encrypt and Decrypt operations
+etag: AA==
+name: roles/cloudkms.cryptoKeyEncrypterDecrypter
+stage: GA
+title: Cloud KMS CryptoKey Encrypter/Decrypter
+---
+description: Enables ImportCryptoKeyVersion, CreateImportJob, ListImportJobs, and
+  GetImportJob operations
+etag: AA==
+name: roles/cloudkms.importer
+stage: GA
+title: Cloud KMS Importer
+---
+description: Enables GetPublicKey operations
+etag: AA==
+name: roles/cloudkms.publicKeyViewer
+stage: GA
+title: Cloud KMS CryptoKey Public Key Viewer
+---
+description: Gives Cloud KMS service account access to managed resources.
+etag: AA==
+name: roles/cloudkms.serviceAgent
+stage: GA
+title: Cloud KMS Service Agent
+---
+description: Enables Sign operations
+etag: AA==
+name: roles/cloudkms.signer
+stage: GA
+title: Cloud KMS CryptoKey Signer
+---
+description: Enables Sign, Verify, and GetPublicKey operations
+etag: AA==
+name: roles/cloudkms.signerVerifier
+stage: GA
+title: Cloud KMS CryptoKey Signer/Verifier
+---
+description: Ability to create and manage Compute VMs to run Velostrata Infrastructure
+etag: AA==
+name: roles/cloudmigration.inframanager
+stage: BETA
+title: Velostrata Manager
+---
+description: Ability to access migration storage
+etag: AA==
+name: roles/cloudmigration.storageaccess
+stage: BETA
+title: Velostrata Storage Access
+---
+description: Ability to set up connection between Velostrata Manager and Google
+etag: AA==
+name: roles/cloudmigration.velostrataconnect
+stage: BETA
+title: Velostrata Manager Connection Agent
+---
+description: Grants Cloud Optimization Service Account access to read and write data
+  in the user project.
+etag: AA==
+name: roles/cloudoptimization.serviceAgent
+stage: GA
+title: Cloud Optimization Service Agent
+---
+description: Can browse catalogs in the target resource context.
+etag: AA==
+name: roles/cloudprivatecatalog.consumer
+stage: BETA
+title: Catalog Consumer
+---
+description: Can manage catalog and view its associations.
+etag: AA==
+name: roles/cloudprivatecatalogproducer.admin
+stage: BETA
+title: Catalog Admin
+---
+description: Can manage associations between a catalog and a target resource.
+etag: AA==
+name: roles/cloudprivatecatalogproducer.manager
+stage: BETA
+title: Catalog Manager
+---
+description: Can manage catalog org settings.
+etag: AA==
+name: roles/cloudprivatecatalogproducer.orgAdmin
+stage: BETA
+title: Catalog Org Admin
+---
+description: Cloud Profiler agents are allowed to register and provide the profiling
+  data.
+etag: AA==
+name: roles/cloudprofiler.agent
+stage: GA
+title: Cloud Profiler Agent
+---
+description: Cloud Profiler users are allowed to query and view the profiling data.
+etag: AA==
+name: roles/cloudprofiler.user
+stage: GA
+title: Cloud Profiler User
+---
+description: Full access to jobs and executions.
+etag: AA==
+name: roles/cloudscheduler.admin
+stage: GA
+title: Cloud Scheduler Admin
+---
+description: Access to run jobs.
+etag: AA==
+name: roles/cloudscheduler.jobRunner
+stage: GA
+title: Cloud Scheduler Job Runner
+---
+description: Grants Cloud Scheduler Service Account access to manage resources.
+etag: AA==
+name: roles/cloudscheduler.serviceAgent
+stage: GA
+title: Cloud Scheduler Service Agent
+---
+description: Get and list access to jobs, executions, and locations.
+etag: AA==
+name: roles/cloudscheduler.viewer
+stage: GA
+title: Cloud Scheduler Viewer
+---
+description: Full access to all Web Security Scanner resources
+etag: AA==
+name: roles/cloudsecurityscanner.editor
+stage: GA
+title: Web Security Scanner Editor
+---
+description: Read access to Scan and ScanRun, plus the ability to start scans
+etag: AA==
+name: roles/cloudsecurityscanner.runner
+stage: GA
+title: Web Security Scanner Runner
+---
+description: Read access to all Web Security Scanner resources
+etag: AA==
+name: roles/cloudsecurityscanner.viewer
+stage: GA
+title: Web Security Scanner Viewer
+---
+description: Full control of Cloud SQL resources.
+etag: AA==
+name: roles/cloudsql.admin
+stage: GA
+title: Cloud SQL Admin
+---
+description: Connectivity access to Cloud SQL instances.
+etag: AA==
+name: roles/cloudsql.client
+stage: GA
+title: Cloud SQL Client
+---
+description: Full control of existing Cloud SQL instances excluding modifying users,
+  SSL certificates or deleting resources.
+etag: AA==
+name: roles/cloudsql.editor
+stage: GA
+title: Cloud SQL Editor
+---
+description: Role allowing access to a Cloud SQL instance
+etag: AA==
+name: roles/cloudsql.instanceUser
+stage: GA
+title: Cloud SQL Instance User
+---
+description: Grants Cloud SQL access to services and APIs in the user project
+etag: AA==
+name: roles/cloudsql.serviceAgent
+stage: GA
+title: Cloud SQL Service Agent
+---
+description: Read-only access to Cloud SQL resources.
+etag: AA==
+name: roles/cloudsql.viewer
+stage: GA
+title: Cloud SQL Viewer
+---
+description: Allows management of a support account without giving access to support
+  cases.
+etag: AA==
+name: roles/cloudsupport.admin
+stage: GA
+title: Support Account Administrator
+---
+description: Full read-write access to technical support cases (applicable for GCP
+  Customer Care and Maps support).
+etag: AA==
+name: roles/cloudsupport.techSupportEditor
+stage: GA
+title: Tech Support Editor
+---
+description: Read-only access to technical support cases (applicable for GCP Customer
+  Care and Maps support).
+etag: AA==
+name: roles/cloudsupport.techSupportViewer
+stage: GA
+title: Tech Support Viewer
+---
+description: Read-only access to details of a support account. This does not allow
+  viewing cases.
+etag: AA==
+name: roles/cloudsupport.viewer
+stage: GA
+title: Support Account Viewer
+---
+description: Full access to queues and tasks.
+etag: AA==
+name: roles/cloudtasks.admin
+stage: BETA
+title: Cloud Tasks Admin
+---
+description: Access to create tasks.
+etag: AA==
+name: roles/cloudtasks.enqueuer
+stage: BETA
+title: Cloud Tasks Enqueuer
+---
+description: Admin access to queues.
+etag: AA==
+name: roles/cloudtasks.queueAdmin
+stage: BETA
+title: Cloud Tasks Queue Admin
+---
+description: Grants Cloud Tasks Service Account access to manage resources.
+etag: AA==
+name: roles/cloudtasks.serviceAgent
+stage: GA
+title: Cloud Tasks Service Agent
+---
+description: Access to delete tasks.
+etag: AA==
+name: roles/cloudtasks.taskDeleter
+stage: BETA
+title: Cloud Tasks Task Deleter
+---
+description: Access to run tasks.
+etag: AA==
+name: roles/cloudtasks.taskRunner
+stage: BETA
+title: Cloud Tasks Task Runner
+---
+description: Get and list access to tasks, queues, and locations.
+etag: AA==
+name: roles/cloudtasks.viewer
+stage: BETA
+title: Cloud Tasks Viewer
+---
+description: Full access to all Test Lab features
+etag: AA==
+name: roles/cloudtestservice.testAdmin
+stage: GA
+title: Firebase Test Lab Admin
+---
+description: Read access to Test Lab features
+etag: AA==
+name: roles/cloudtestservice.testViewer
+stage: GA
+title: Firebase Test Lab Viewer
+---
+description: Give Cloud TPUs service account access to managed resources
+etag: AA==
+name: roles/cloudtpu.serviceAgent
+stage: GA
+title: Cloud TPU V2 API Service Agent
+---
+description: Admin access to Stackdriver Trace.
+etag: AA==
+name: roles/cloudtrace.admin
+stage: GA
+title: Cloud Trace Admin
+---
+description: Agent access to Stackdriver Trace. Can write trace data.
+etag: AA==
+name: roles/cloudtrace.agent
+stage: GA
+title: Cloud Trace Agent
+---
+description: User access to Stackdriver Trace. Can view traces, insights and stats.
+  Can create, list, view, and delete tasks.
+etag: AA==
+name: roles/cloudtrace.user
+stage: GA
+title: Cloud Trace User
+---
+description: Full access to all Cloud Translation resources
+etag: AA==
+name: roles/cloudtranslate.admin
+stage: GA
+title: Cloud Translation API Admin
+---
+description: Editor of all Cloud Translation resources
+etag: AA==
+name: roles/cloudtranslate.editor
+stage: GA
+title: Cloud Translation API Editor
+---
+description: Gives Cloud Translation Service Account access to consumer resources.
+etag: AA==
+name: roles/cloudtranslate.serviceAgent
+stage: GA
+title: Cloud Translation API Service Agent
+---
+description: User of Cloud Translation and AutoML models
+etag: AA==
+name: roles/cloudtranslate.user
+stage: GA
+title: Cloud Translation API User
+---
+description: Viewer of all Translation resources
+etag: AA==
+name: roles/cloudtranslate.viewer
+stage: GA
+title: Cloud Translation API Viewer
+---
+description: Full access to API keys
+etag: AA==
+name: roles/codelabapikeys.admin
+stage: BETA
+title: Codelab ApiKeys Admin
+---
+description: This role can view and edit all properties of API keys.
+etag: AA==
+name: roles/codelabapikeys.editor
+stage: BETA
+title: Codelab API Keys Editor
+---
+description: This role can view all properties except change history of API keys.
+etag: AA==
+name: roles/codelabapikeys.viewer
+stage: BETA
+title: Codelab API Keys Viewer
+---
+description: Allows viewing offers
+etag: AA==
+name: roles/commerceoffercatalog.offersViewer
+stage: BETA
+title: Commerce Offer Catalog Offers Viewer
+---
+description: Allows managing private offers
+etag: AA==
+name: roles/commercepricemanagement.privateOffersAdmin
+stage: BETA
+title: Commerce Price Management Private Offers Admin
+---
+description: Allows viewing offers, free trials, skus
+etag: AA==
+name: roles/commercepricemanagement.viewer
+stage: BETA
+title: Commerce Price Management Viewer
+---
+description: Full control of Composer resources.
+etag: AA==
+name: roles/composer.admin
+stage: GA
+title: Composer Administrator
+---
+description: Full control of Cloud Composer environments and Cloud Storage objects.
+etag: AA==
+name: roles/composer.environmentAndStorageObjectAdmin
+stage: GA
+title: Environment and Storage Object Administrator
+---
+description: Read access to Cloud Composer environments and Cloud Storage objects.
+etag: AA==
+name: roles/composer.environmentAndStorageObjectViewer
+stage: GA
+title: Environment User and Storage Object Viewer
+---
+description: Cloud Composer API service agent can manage environments.
+etag: AA==
+name: roles/composer.serviceAgent
+stage: GA
+title: Cloud Composer API Service Agent
+---
+description: Role that should be assigned to Composer Agent service account in Shared
+  VPC host project
+etag: AA==
+name: roles/composer.sharedVpcAgent
+stage: GA
+title: Composer Shared VPC Agent
+---
+description: Read and use access to Composer resources.
+etag: AA==
+name: roles/composer.user
+stage: GA
+title: Composer User
+---
+description: Worker access to Composer. Intended for service accounts.
+etag: AA==
+name: roles/composer.worker
+stage: GA
+title: Composer Worker
+---
+description: Full control of all Compute Engine resources.
+etag: AA==
+name: roles/compute.admin
+stage: GA
+title: Compute Admin
+---
+description: Read and use image resources.
+etag: AA==
+name: roles/compute.imageUser
+stage: GA
+title: Compute Image User
+---
+description: Full control of Compute Engine instance resources.
+etag: AA==
+name: roles/compute.instanceAdmin
+stage: GA
+title: Compute Instance Admin (beta)
+---
+description: Full control of Compute Engine instances, instance groups, disks, snapshots,
+  and images. Read access to all Compute Engine networking resources.
+etag: AA==
+name: roles/compute.instanceAdmin.v1
+stage: GA
+title: Compute Instance Admin (v1)
+---
+description: Full control of Compute Engine resources related to load balancer.
+etag: AA==
+name: roles/compute.loadBalancerAdmin
+stage: BETA
+title: Compute Load Balancer Admin
+---
+description: Full control of Compute Engine networking resources.
+etag: AA==
+name: roles/compute.networkAdmin
+stage: GA
+title: Compute Network Admin
+---
+description: Access to use Compute Engine networking resources.
+etag: AA==
+name: roles/compute.networkUser
+stage: GA
+title: Compute Network User
+---
+description: Read-only access to Compute Engine networking resources.
+etag: AA==
+name: roles/compute.networkViewer
+stage: GA
+title: Compute Network Viewer
+---
+description: Full control of Compute Engine Organization Firewall Policies.
+etag: AA==
+name: roles/compute.orgFirewallPolicyAdmin
+stage: GA
+title: Compute Organization Firewall Policy Admin
+---
+description: View or use Compute Engine Firewall Policies to associate with the organization
+  or folders.
+etag: AA==
+name: roles/compute.orgFirewallPolicyUser
+stage: GA
+title: Compute Organization Firewall Policy User
+---
+description: Full control of Compute Engine Organization Security Policies.
+etag: AA==
+name: roles/compute.orgSecurityPolicyAdmin
+stage: GA
+title: Compute Organization Security Policy Admin
+---
+description: View or use Compute Engine Security Policies to associate with the organization
+  or folders.
+etag: AA==
+name: roles/compute.orgSecurityPolicyUser
+stage: GA
+title: Compute Organization Security Policy User
+---
+description: Full control of Compute Engine Firewall Policy associations to the organization
+  or folders.
+etag: AA==
+name: roles/compute.orgSecurityResourceAdmin
+stage: GA
+title: Compute Organization Resource Admin
+---
+description: Access to log in to a Compute Engine instance as an administrator user.
+etag: AA==
+name: roles/compute.osAdminLogin
+stage: GA
+title: Compute OS Admin Login
+---
+description: Access to log in to a Compute Engine instance as a standard (non-administrator)
+  user.
+etag: AA==
+name: roles/compute.osLogin
+stage: GA
+title: Compute OS Login
+---
+description: Access for an external user to set OS Login information associated with
+  this organization. This role does not grant access to instances. External users
+  must be granted one of the required OS Login IAM roles (https://cloud.google.com/compute/docs/instances/managing-instance-access#configure_users)
+  in order to allow access to instances using SSH.
+etag: AA==
+name: roles/compute.osLoginExternalUser
+stage: GA
+title: Compute OS Login External User
+---
+description: Specify resources to be mirrored.
+etag: AA==
+name: roles/compute.packetMirroringAdmin
+stage: GA
+title: Compute packet mirroring admin
+---
+description: Use Compute Engine packet mirrorings.
+etag: AA==
+name: roles/compute.packetMirroringUser
+stage: GA
+title: Compute packet mirroring user
+---
+description: Full control of public IP address management for Compute Engine.
+etag: AA==
+name: roles/compute.publicIpAdmin
+stage: GA
+title: Compute Public IP Admin
+---
+description: Full control of Compute Engine security resources.
+etag: AA==
+name: roles/compute.securityAdmin
+stage: GA
+title: Compute Security Admin
+---
+description: Gives Compute Engine Service Account access to assert service account
+  authority. Includes access to service accounts.
+etag: AA==
+name: roles/compute.serviceAgent
+stage: GA
+title: Compute Engine Service Agent
+---
+description: Full control of Compute Engine storage resources.
+etag: AA==
+name: roles/compute.storageAdmin
+stage: GA
+title: Compute Storage Admin
+---
+description: Read-only access to get and list information about all Compute Engine
+  resources, including instances, disks, and firewalls. Allows getting and listing
+  information about disks, images, and snapshots, but does not allow reading the data
+  stored on them.
+etag: AA==
+name: roles/compute.viewer
+stage: GA
+title: Compute Viewer
+---
+description: Can administer shared VPC network (XPN).
+etag: AA==
+name: roles/compute.xpnAdmin
+stage: GA
+title: Compute Shared VPC Admin
+---
+description: Gives Compute Scanning Service Account access to viewGoogle Compute Engine
+  Images
+etag: AA==
+name: roles/computescanning.serviceAgent
+stage: GA
+title: Compute Scanning Service Agent
+---
+description: Allows managing entitlements and enabling, disabling, and inspecting
+  service states for a consumer project
+etag: AA==
+name: roles/consumerprocurement.entitlementManager
+stage: BETA
+title: Consumer Procurement Entitlement Manager
+---
+description: Allows inspecting entitlements and service states for a consumer project
+etag: AA==
+name: roles/consumerprocurement.entitlementViewer
+stage: BETA
+title: Consumer Procurement Entitlement Viewer
+---
+description: Allows managing purchases
+etag: AA==
+name: roles/consumerprocurement.orderAdmin
+stage: BETA
+title: Consumer Procurement Order Administrator
+---
+description: Allows inspecting purchases
+etag: AA==
+name: roles/consumerprocurement.orderViewer
+stage: BETA
+title: Consumer Procurement Order Viewer
+---
+description: Grants read and write access to all Contact Center AI Insights resources.
+etag: AA==
+name: roles/contactcenterinsights.editor
+stage: BETA
+title: Contact Center AI Insights editor
+---
+description: Allows Contact Center AI to read and write APIs including BigQuery, Dialogflow,
+  and Storage.
+etag: AA==
+name: roles/contactcenterinsights.serviceAgent
+stage: GA
+title: Contact Center AI Insights Service Agent
+---
+description: Grants read access to all Contact Center AI Insights resources.
+etag: AA==
+name: roles/contactcenterinsights.viewer
+stage: BETA
+title: Contact Center AI Insights viewer
+---
+description: Full management of Kubernetes Clusters and their Kubernetes API objects.
+etag: AA==
+name: roles/container.admin
+stage: GA
+title: Kubernetes Engine Admin
+---
+description: Management of Kubernetes Clusters.
+etag: AA==
+name: roles/container.clusterAdmin
+stage: GA
+title: Kubernetes Engine Cluster Admin
+---
+description: Get and list access to GKE Clusters.
+etag: AA==
+name: roles/container.clusterViewer
+stage: GA
+title: Kubernetes Engine Cluster Viewer
+---
+description: Full access to Kubernetes API objects inside Kubernetes Clusters.
+etag: AA==
+name: roles/container.developer
+stage: GA
+title: Kubernetes Engine Developer
+---
+description: Allows the Kubernetes Engine service account in the host project to configure
+  shared network resources for cluster management. Also gives access to inspect the
+  firewall rules in the host project, and configure Cloud DNS resources.
+etag: AA==
+name: roles/container.hostServiceAgentUser
+stage: GA
+title: Kubernetes Engine Host Service Agent User
+---
+description: Gives Kubernetes Engine account access to manage cluster resources. Includes
+  access to service accounts.
+etag: AA==
+name: roles/container.serviceAgent
+stage: GA
+title: Kubernetes Engine Service Agent
+---
+description: Read-only access to Kubernetes Engine resources.
+etag: AA==
+name: roles/container.viewer
+stage: GA
+title: Kubernetes Engine Viewer
+---
+description: Gives Container Analysis API the access it needs to function
+etag: AA==
+name: roles/containeranalysis.ServiceAgent
+stage: GA
+title: Container Analysis Service Agent
+---
+description: Access to all Container Analysis resources.
+etag: AA==
+name: roles/containeranalysis.admin
+stage: GA
+title: Container Analysis Admin
+---
+description: Can attach Container Analysis Occurrences to Notes.
+etag: AA==
+name: roles/containeranalysis.notes.attacher
+stage: GA
+title: Container Analysis Notes Attacher
+---
+description: Can edit Container Analysis Notes.
+etag: AA==
+name: roles/containeranalysis.notes.editor
+stage: GA
+title: Container Analysis Notes Editor
+---
+description: Can view all Container Analysis Occurrences attached to a Note.
+etag: AA==
+name: roles/containeranalysis.notes.occurrences.viewer
+stage: GA
+title: Container Analysis Occurrences for Notes Viewer
+---
+description: Can view Container Analysis Notes.
+etag: AA==
+name: roles/containeranalysis.notes.viewer
+stage: GA
+title: Container Analysis Notes Viewer
+---
+description: Can edit Container Analysis Occurrences.
+etag: AA==
+name: roles/containeranalysis.occurrences.editor
+stage: GA
+title: Container Analysis Occurrences Editor
+---
+description: Can view Container Analysis Occurrences.
+etag: AA==
+name: roles/containeranalysis.occurrences.viewer
+stage: GA
+title: Container Analysis Occurrences Viewer
+---
+description: Access for Container Registry
+etag: AA==
+name: roles/containerregistry.ServiceAgent
+stage: GA
+title: Container Registry Service Agent
+---
+description: Gives Container Scanner the access it needs to analyzecontainers for
+  vulnerabilities and create occurrences using the Container Analysis API
+etag: AA==
+name: roles/containerscanning.ServiceAgent
+stage: GA
+title: Container Scanner Service Agent
+---
+description: Gives Container Threat Detection service account access to enable/disable
+  Container Threat Detection and manage the Container Threat Detection Agent on Google
+  Kubernetes Engine clusters.
+etag: AA==
+name: roles/containerthreatdetection.serviceAgent
+stage: GA
+title: Container Threat Detection Service Agent
+---
+description: Gives the Content Warehouse service account to manage customer resources
+etag: AA==
+name: roles/contentwarehouse.serviceAgent
+stage: GA
+title: Content Warehouse Service Agent
+---
+description: Full access to all DataCatalog resources
+etag: AA==
+name: roles/datacatalog.admin
+stage: GA
+title: Data Catalog Admin
+---
+description: Manage taxonomies
+etag: AA==
+name: roles/datacatalog.categoryAdmin
+stage: BETA
+title: Policy Tag Admin
+---
+description: Read access to sub-resources tagged by a policy tag, for example, BigQuery
+  columns
+etag: AA==
+name: roles/datacatalog.categoryFineGrainedReader
+stage: BETA
+title: Fine-Grained Reader
+---
+description: Can create new entryGroups
+etag: AA==
+name: roles/datacatalog.entryGroupCreator
+stage: GA
+title: DataCatalog EntryGroup Creator
+---
+description: Full access to entryGroups
+etag: AA==
+name: roles/datacatalog.entryGroupOwner
+stage: GA
+title: DataCatalog entryGroup Owner
+---
+description: Full access to entries
+etag: AA==
+name: roles/datacatalog.entryOwner
+stage: GA
+title: DataCatalog entry Owner
+---
+description: Read access to entries
+etag: AA==
+name: roles/datacatalog.entryViewer
+stage: GA
+title: DataCatalog Entry Viewer
+---
+description: Gives permission to modify tags on a GCP assets (BigQuery, Pub/Sub etc).
+etag: AA==
+name: roles/datacatalog.tagEditor
+stage: GA
+title: Data Catalog Tag Editor
+---
+description: Access to create new tag templates
+etag: AA==
+name: roles/datacatalog.tagTemplateCreator
+stage: GA
+title: Data Catalog TagTemplate Creator
+---
+description: Full acess to tag templates
+etag: AA==
+name: roles/datacatalog.tagTemplateOwner
+stage: GA
+title: Data Catalog TagTemplate Owner
+---
+description: Access to use templates to tag resources
+etag: AA==
+name: roles/datacatalog.tagTemplateUser
+stage: GA
+title: Data Catalog TagTemplate User
+---
+description: Read access to templates and tags created using the templates
+etag: AA==
+name: roles/datacatalog.tagTemplateViewer
+stage: GA
+title: Data Catalog TagTemplate Viewer
+---
+description: Grants metadata read permissions to cataloged GCP assets (BigQuery, Pub/Sub
+  etc)
+etag: AA==
+name: roles/datacatalog.viewer
+stage: GA
+title: Data Catalog Viewer
+---
+description: Minimal role for creating and managing dataflow jobs.
+etag: AA==
+name: roles/dataflow.admin
+stage: GA
+title: Dataflow Admin
+---
+description: Full operational access to Dataflow jobs.
+etag: AA==
+name: roles/dataflow.developer
+stage: GA
+title: Dataflow Developer
+---
+description: Gives Cloud Dataflow service account access to managed resources. Includes
+  access to service accounts.
+etag: AA==
+name: roles/dataflow.serviceAgent
+stage: GA
+title: Cloud Dataflow Service Agent
+---
+description: Read only access to Dataflow jobs.
+etag: AA==
+name: roles/dataflow.viewer
+stage: GA
+title: Dataflow Viewer
+---
+description: Worker access to Dataflow.  Intended for service accounts.
+etag: AA==
+name: roles/dataflow.worker
+stage: GA
+title: Dataflow Worker
+---
+description: Full access to Cloud Data Fusion Instances and related resources.
+etag: AA==
+name: roles/datafusion.admin
+stage: BETA
+title: Cloud Data Fusion Admin
+---
+description: Access to Cloud Data Fusion runtime resources.
+etag: AA==
+name: roles/datafusion.runner
+stage: BETA
+title: Cloud Data Fusion Runner
+---
+description: Gives Cloud Data Fusion service account access to Service Networking,
+  Cloud Dataproc, Cloud Storage, BigQuery, Cloud Spanner, and Cloud Bigtable resources.
+etag: AA==
+name: roles/datafusion.serviceAgent
+stage: GA
+title: Cloud Data Fusion API Service Agent
+---
+description: Read-only access to Cloud Data Fusion Instances and related resources.
+etag: AA==
+name: roles/datafusion.viewer
+stage: BETA
+title: Cloud Data Fusion Viewer
+---
+description: Full access to all DataLabeling resources
+etag: AA==
+name: roles/datalabeling.admin
+stage: BETA
+title: DataLabeling Service Admin
+---
+description: Editor of all DataLabeling resources
+etag: AA==
+name: roles/datalabeling.editor
+stage: BETA
+title: DataLabeling Service Editor
+---
+description: Gives DataLabeling service account read/write access to Cloud Storage,
+  read/write BigQuery, update CMLE model versions, editor access to Annotation service
+  and AutoML service.
+etag: AA==
+name: roles/datalabeling.serviceAgent
+stage: GA
+title: DataLabeling Service Agent
+---
+description: Viewer of all DataLabeling resources
+etag: AA==
+name: roles/datalabeling.viewer
+stage: BETA
+title: DataLabeling Service Viewer
+---
+description: Full access to all resources of Database Migration.
+etag: AA==
+name: roles/datamigration.admin
+stage: GA
+title: Database Migration Admin
+---
+description: Use of Dataprep.
+etag: AA==
+name: roles/dataprep.projects.user
+stage: BETA
+title: Dataprep User
+---
+description: Dataprep service identity. Includes access to service accounts.
+etag: AA==
+name: roles/dataprep.serviceAgent
+stage: GA
+title: Dataprep Service Agent
+---
+description: Full control of Dataproc resources.
+etag: AA==
+name: roles/dataproc.admin
+stage: GA
+title: Dataproc Administrator
+---
+description: Full control of Dataproc resources. Allows viewing all networks.
+etag: AA==
+name: roles/dataproc.editor
+stage: GA
+title: Dataproc Editor
+---
+description: Allows management of Dataproc resources. Intended for service accounts
+  running Dataproc Hub instances.
+etag: AA==
+name: roles/dataproc.hubAgent
+stage: GA
+title: Dataproc Hub Agent
+---
+description: Gives Cloud Dataproc service account access to Compute, and Storage resources
+  and Service Accounts.
+etag: AA==
+name: roles/dataproc.serviceAgent
+stage: GA
+title: Dataproc Service Agent
+---
+description: Read-only access to Dataproc resources.
+etag: AA==
+name: roles/dataproc.viewer
+stage: GA
+title: Dataproc Viewer
+---
+description: Worker access to Dataproc. Intended for service accounts.
+etag: AA==
+name: roles/dataproc.worker
+stage: GA
+title: Dataproc Worker
+---
+description: Data processing controls admin who can fully manage data processing controls
+  settings and view all datasource data.
+etag: AA==
+name: roles/dataprocessing.admin
+stage: GA
+title: Data Processing Controls Resource Admin
+---
+description: Full access to manage imports and exports.
+etag: AA==
+name: roles/datastore.importExportAdmin
+stage: GA
+title: Cloud Datastore Import Export Admin
+---
+description: Full access to manage index definitions.
+etag: AA==
+name: roles/datastore.indexAdmin
+stage: GA
+title: Cloud Datastore Index Admin
+---
+description: Full access to Cloud Datastore.
+etag: AA==
+name: roles/datastore.owner
+stage: GA
+title: Cloud Datastore Owner
+---
+description: Provides read/write access to data in a Cloud Datastore database. Intended
+  for application developers and service accounts.
+etag: AA==
+name: roles/datastore.user
+stage: GA
+title: Cloud Datastore User
+---
+description: Read access to all Cloud Datastore resources.
+etag: AA==
+name: roles/datastore.viewer
+stage: GA
+title: Cloud Datastore Viewer
+---
+description: Full access to all Datastream resources.
+etag: AA==
+name: roles/datastream.admin
+stage: BETA
+title: Datastream Admin
+---
+description: Read-only access to all Datastream resources.
+etag: AA==
+name: roles/datastream.viewer
+stage: BETA
+title: Datastream Viewer
+---
+description: Grants Data Studio Service Account access to manage resources.
+etag: AA==
+name: roles/datastudio.serviceAgent
+stage: GA
+title: Data Studio Service Agent
+---
+description: This role is managed by Dell EMC, not Google.
+etag: AA==
+name: roles/dellemccloudonefs.admin
+stage: BETA
+title: Dell EMC Cloud OneFS Admin
+---
+description: This role is managed by Dell EMC, not Google.
+etag: AA==
+name: roles/dellemccloudonefs.user
+stage: BETA
+title: Dell EMC Cloud OneFS User
+---
+description: This role is managed by Dell EMC, not Google.
+etag: AA==
+name: roles/dellemccloudonefs.viewer
+stage: BETA
+title: Dell EMC Cloud OneFS Viewer
+---
+description: Read and Write access to all Deployment Manager resources.
+etag: AA==
+name: roles/deploymentmanager.editor
+stage: GA
+title: Deployment Manager Editor
+---
+description: Read and Write access to all Type Registry resources.
+etag: AA==
+name: roles/deploymentmanager.typeEditor
+stage: GA
+title: Deployment Manager Type Editor
+---
+description: Read-only access to all Type Registry resources.
+etag: AA==
+name: roles/deploymentmanager.typeViewer
+stage: GA
+title: Deployment Manager Type Viewer
+---
+description: Read-only access to all Deployment Manager resources.
+etag: AA==
+name: roles/deploymentmanager.viewer
+stage: GA
+title: Deployment Manager Viewer
+---
+description: An admin has access to all resources and can perform all administrative
+  actions in an AAM project.
+etag: AA==
+name: roles/dialogflow.aamAdmin
+stage: GA
+title: AAM Admin
+---
+description: A Conversational Architect can label conversational data, approve taxonomy
+  changes and design virtual agents for a customer's use cases.
+etag: AA==
+name: roles/dialogflow.aamConversationalArchitect
+stage: GA
+title: AAM Conversational Architect
+---
+description: A Dialog Designer can label conversational data and propose taxonomy
+  changes for virtual agent modeling.
+etag: AA==
+name: roles/dialogflow.aamDialogDesigner
+stage: GA
+title: AAM Dialog Designer
+---
+description: A Dialog Designer Lead can label conversational data and approve taxonomy
+  changes for virtual agent modeling.
+etag: AA==
+name: roles/dialogflow.aamLeadDialogDesigner
+title: AAM Lead Dialog Designer
+---
+description: A user can view the taxonomy and data reports in an AAM project.
+etag: AA==
+name: roles/dialogflow.aamViewer
+stage: GA
+title: AAM Viewer
+---
+description: Can query for intent; read & write session properties; read & write agent
+  properties.
+etag: AA==
+name: roles/dialogflow.admin
+stage: GA
+title: Dialogflow API Admin
+---
+description: Can call all methods on sessions and conversations resources as well
+  as their descendants.
+etag: AA==
+name: roles/dialogflow.client
+stage: GA
+title: Dialogflow API Client
+---
+description: Can edit agent in Dialogflow Console
+etag: AA==
+name: roles/dialogflow.consoleAgentEditor
+stage: GA
+title: Dialogflow Console Agent Editor
+---
+description: Can perform query of dialogflow suggestions in the simulator in web console.
+etag: AA==
+name: roles/dialogflow.consoleSimulatorUser
+stage: GA
+title: Dialogflow Console Simulator User
+---
+description: Can edit allowlist for smart messaging associated with conversation model
+  in the agent assist console
+etag: AA==
+name: roles/dialogflow.consoleSmartMessagingAllowlistEditor
+stage: GA
+title: Dialogflow Console Smart Messaging Allowlist Editor
+---
+description: Can manage all the resources related to Dialogflow Conversations.
+etag: AA==
+name: roles/dialogflow.conversationManager
+stage: GA
+title: Dialogflow Conversation Manager
+---
+description: Can add, remove, enable and disable Dialogflow integrations.
+etag: AA==
+name: roles/dialogflow.integrationManager
+stage: GA
+title: Dialogflow Integration Manager
+---
+description: Can read agent and session properties; cannot query for intent.
+etag: AA==
+name: roles/dialogflow.reader
+stage: GA
+title: Dialogflow API Reader
+---
+description: Gives Dialogflow Service Account access to resources on behalf of user
+  project for intent detection in integrations (Facebook Messenger, Slack, Telephony,
+  etc.).
+etag: AA==
+name: roles/dialogflow.serviceAgent
+stage: GA
+title: Dialogflow Service Agent
+---
+description: Administer DLP including jobs and templates.
+etag: AA==
+name: roles/dlp.admin
+stage: GA
+title: DLP Administrator
+---
+description: Edit DLP analyze risk templates.
+etag: AA==
+name: roles/dlp.analyzeRiskTemplatesEditor
+stage: GA
+title: DLP Analyze Risk Templates Editor
+---
+description: Read DLP analyze risk templates.
+etag: AA==
+name: roles/dlp.analyzeRiskTemplatesReader
+stage: GA
+title: DLP Analyze Risk Templates Reader
+---
+description: Read DLP column profiles.
+etag: AA==
+name: roles/dlp.columnDataProfilesReader
+stage: GA
+title: DLP Column Data Profiles Reader
+---
+description: Read DLP profiles.
+etag: AA==
+name: roles/dlp.dataProfilesReader
+stage: GA
+title: DLP Data Profiles Reader
+---
+description: Edit DLP de-identify templates.
+etag: AA==
+name: roles/dlp.deidentifyTemplatesEditor
+stage: GA
+title: DLP De-identify Templates Editor
+---
+description: Read DLP de-identify templates.
+etag: AA==
+name: roles/dlp.deidentifyTemplatesReader
+stage: GA
+title: DLP De-identify Templates Reader
+---
+description: Manage DLP Cost Estimates.
+etag: AA==
+name: roles/dlp.estimatesAdmin
+stage: GA
+title: DLP Cost Estimation
+---
+description: Read DLP stored findings.
+etag: AA==
+name: roles/dlp.inspectFindingsReader
+stage: GA
+title: DLP Inspect Findings Reader
+---
+description: Edit DLP inspect templates.
+etag: AA==
+name: roles/dlp.inspectTemplatesEditor
+stage: GA
+title: DLP Inspect Templates Editor
+---
+description: Read DLP inspect templates.
+etag: AA==
+name: roles/dlp.inspectTemplatesReader
+stage: GA
+title: DLP Inspect Templates Reader
+---
+description: Edit job triggers configurations.
+etag: AA==
+name: roles/dlp.jobTriggersEditor
+stage: GA
+title: DLP Job Triggers Editor
+---
+description: Read job triggers.
+etag: AA==
+name: roles/dlp.jobTriggersReader
+stage: GA
+title: DLP Job Triggers Reader
+---
+description: Edit and create jobs
+etag: AA==
+name: roles/dlp.jobsEditor
+stage: GA
+title: DLP Jobs Editor
+---
+description: Read jobs
+etag: AA==
+name: roles/dlp.jobsReader
+stage: GA
+title: DLP Jobs Reader
+---
+description: Read DLP project profiles.
+etag: AA==
+name: roles/dlp.projectDataProfilesReader
+stage: GA
+title: DLP Project Data Profiles Reader
+---
+description: Read DLP entities, such as jobs and templates.
+etag: AA==
+name: roles/dlp.reader
+stage: GA
+title: DLP Reader
+---
+description: Gives DLP API service agent permissions for biquery, storage, datastore,
+  pubsub and KMS.
+etag: AA==
+name: roles/dlp.serviceAgent
+stage: GA
+title: DLP API Service Agent
+---
+description: Edit DLP stored info types.
+etag: AA==
+name: roles/dlp.storedInfoTypesEditor
+stage: GA
+title: DLP Stored InfoTypes Editor
+---
+description: Read DLP stored info types.
+etag: AA==
+name: roles/dlp.storedInfoTypesReader
+stage: GA
+title: DLP Stored InfoTypes Reader
+---
+description: Read DLP table profiles.
+etag: AA==
+name: roles/dlp.tableDataProfilesReader
+stage: GA
+title: DLP Table Data Profiles Reader
+---
+description: Inspect, Redact, and De-identify Content
+etag: AA==
+name: roles/dlp.user
+stage: GA
+title: DLP User
+---
+description: Full read-write access to DNS resources.
+etag: AA==
+name: roles/dns.admin
+stage: GA
+title: DNS Administrator
+---
+description: Access to target networks with DNS peering zones
+etag: AA==
+name: roles/dns.peer
+stage: GA
+title: DNS Peer
+---
+description: Read-only access to DNS resources.
+etag: AA==
+name: roles/dns.reader
+stage: GA
+title: DNS Reader
+---
+description: Grants full access to all resources in Cloud DocumentAI
+etag: AA==
+name: roles/documentai.admin
+stage: BETA
+title: Cloud DocumentAI Administrator.
+---
+description: Grants access to process documents in Cloud DocumentAI
+etag: AA==
+name: roles/documentai.apiUser
+stage: BETA
+title: Cloud DocumentAI API User
+---
+description: Grants access to use all resources in Cloud DocumentAI
+etag: AA==
+name: roles/documentai.editor
+stage: BETA
+title: Cloud DocumentAI Editor
+---
+description: Grants access to view all resources and process documents in Cloud DocumentAI
+etag: AA==
+name: roles/documentai.viewer
+stage: BETA
+title: Cloud DocumentAI Viewer
+---
+description: Gives DocumentAI Core Service Account access to consumer resources.
+etag: AA==
+name: roles/documentaicore.serviceAgent
+stage: GA
+title: DocumentAI Core Service Agent
+---
+description: Full access to Cloud Domains Registrations and related resources.
+etag: AA==
+name: roles/domains.admin
+stage: BETA
+title: Cloud Domains Admin
+---
+description: Read-only access to Cloud Domains Registrations and related resources.
+etag: AA==
+name: roles/domains.viewer
+stage: BETA
+title: Cloud Domains Viewer
+---
+description: Grants full access to the Early Access Center, including access to all
+  DATA_READ and DATA_WRITE permissions. Including the ability to enroll into Early
+  Access Campaigns.
+etag: AA==
+name: roles/earlyaccesscenter.admin
+stage: GA
+title: Early Access Center Administrator
+---
+description: Grants view access to the Early Access Center, including access to all
+  DATA_READ but no DATA_WRITE permissions.
+etag: AA==
+name: roles/earlyaccesscenter.viewer
+stage: GA
+title: Early Access Center Viewer
+---
+description: Full access to all Earth Engine resource features
+etag: AA==
+name: roles/earthengine.admin
+stage: BETA
+title: Earth Engine Resource Admin
+---
+description: Publisher of Earth Engine Apps
+etag: AA==
+name: roles/earthengine.appsPublisher
+stage: BETA
+title: Earth Engine Apps Publisher
+---
+description: Viewer of all Earth Engine resources
+etag: AA==
+name: roles/earthengine.viewer
+stage: BETA
+title: Earth Engine Resource Viewer
+---
+description: Writer of all Earth Engine resources
+etag: AA==
+name: roles/earthengine.writer
+stage: BETA
+title: Earth Engine Resource Writer
+---
+description: Edit access to all resources.
+etag: AA==
+name: roles/editor
+stage: GA
+title: Editor
+---
+description: Full access to Endpoints Portal resources
+etag: AA==
+name: roles/endpoints.portalAdmin
+stage: BETA
+title: Endpoints Portal Admin
+---
+description: Gives the Cloud Endpoints service account access to Endpoints services
+  and the ability to act as a service controller.
+etag: AA==
+name: roles/endpoints.serviceAgent
+stage: GA
+title: Cloud Endpoints Service Agent
+---
+description: Can access information about Endpoints services for consumer portal management,
+  and can read Source Repositories for consumer portal custom content.
+etag: AA==
+name: roles/endpointsportal.serviceAgent
+stage: GA
+title: Endpoints Portal Service Agent
+---
+description: Gives Enterprise Knowledge Graph Service Account access to consumer resources.
+etag: AA==
+name: roles/enterpriseknowledgegraph.serviceAgent
+stage: GA
+title: Enterprise Knowledge Graph Service Agent
+---
+description: Administrative access to Error Reporting.
+etag: AA==
+name: roles/errorreporting.admin
+stage: BETA
+title: Error Reporting Admin
+---
+description: User access to Error Reporting. Can list all errors and update their
+  metadata. Can delete error events.
+etag: AA==
+name: roles/errorreporting.user
+stage: BETA
+title: Error Reporting User
+---
+description: Read-only access to all Error Reporting data.
+etag: AA==
+name: roles/errorreporting.viewer
+stage: BETA
+title: Error Reporting Viewer
+---
+description: Can send error events to Error Reporting. Intended for service accounts.
+etag: AA==
+name: roles/errorreporting.writer
+stage: BETA
+title: Error Reporting Writer
+---
+description: Full access to all essential contacts
+etag: AA==
+name: roles/essentialcontacts.admin
+stage: GA
+title: Essential Contacts Admin
+---
+description: Viewer for all essential contacts
+etag: AA==
+name: roles/essentialcontacts.viewer
+stage: GA
+title: Essential Contacts Viewer
+---
+description: Full control over all Eventarc resources.
+etag: AA==
+name: roles/eventarc.admin
+stage: BETA
+title: Eventarc Admin
+---
+description: Access to read and write Eventarc resources.
+etag: AA==
+name: roles/eventarc.developer
+stage: BETA
+title: Eventarc Developer
+---
+description: Can receive events from all event providers.
+etag: AA==
+name: roles/eventarc.eventReceiver
+stage: BETA
+title: Eventarc Event Receiver
+---
+description: Gives Eventarc service account access to managed resources.
+etag: AA==
+name: roles/eventarc.serviceAgent
+stage: GA
+title: Eventarc Service Agent
+---
+description: Can view the state of all Eventarc resources, including IAM policies.
+etag: AA==
+name: roles/eventarc.viewer
+stage: BETA
+title: Eventarc Viewer
+---
+description: Read-write access to Filestore instances and related resources.
+etag: AA==
+name: roles/file.editor
+stage: BETA
+title: Cloud Filestore Editor
+---
+description: Gives Cloud Filestore service account access to managed resources.
+etag: AA==
+name: roles/file.serviceAgent
+stage: GA
+title: Cloud Filestore Service Agent
+---
+description: Read-only access to Filestore instances and related resources.
+etag: AA==
+name: roles/file.viewer
+stage: BETA
+title: Cloud Filestore Viewer
+---
+description: Full access to Firebase products.
+etag: AA==
+name: roles/firebase.admin
+stage: GA
+title: Firebase Admin
+---
+description: Full access to Google Analytics for Firebase.
+etag: AA==
+name: roles/firebase.analyticsAdmin
+stage: GA
+title: Firebase Analytics Admin
+---
+description: Read access to Google Analytics for Firebase.
+etag: AA==
+name: roles/firebase.analyticsViewer
+stage: GA
+title: Firebase Analytics Viewer
+---
+description: Read and write access to Firebase App Distribution with the Admin SDK
+etag: AA==
+name: roles/firebase.appDistributionSdkServiceAgent
+stage: GA
+title: Firebase App Distribution Admin SDK Service Agent
+---
+description: Full access to Firebase Develop products and Analytics.
+etag: AA==
+name: roles/firebase.developAdmin
+stage: GA
+title: Firebase Develop Admin
+---
+description: Read access to Firebase Develop products and Analytics.
+etag: AA==
+name: roles/firebase.developViewer
+stage: GA
+title: Firebase Develop Viewer
+---
+description: Full access to Firebase Grow products and Analytics.
+etag: AA==
+name: roles/firebase.growthAdmin
+stage: GA
+title: Firebase Grow Admin
+---
+description: Read access to Firebase Grow products and Analytics.
+etag: AA==
+name: roles/firebase.growthViewer
+stage: GA
+title: Firebase Grow Viewer
+---
+description: Access to create new service agents for Firebase projects; assign roles
+  to service agents; provision GCP resources as required by Firebase services.
+etag: AA==
+name: roles/firebase.managementServiceAgent
+stage: GA
+title: Firebase Service Management Service Agent
+---
+description: Full access to Firebase Quality products and Analytics.
+etag: AA==
+name: roles/firebase.qualityAdmin
+stage: GA
+title: Firebase Quality Admin
+---
+description: Read access to Firebase Quality products and Analytics.
+etag: AA==
+name: roles/firebase.qualityViewer
+stage: GA
+title: Firebase Quality Viewer
+---
+description: Read and write access to Firebase products available in the Admin SDK
+etag: AA==
+name: roles/firebase.sdkAdminServiceAgent
+stage: GA
+title: Firebase Admin SDK Administrator Service Agent
+---
+description: Access to provision apps with the Admin SDK.
+etag: AA==
+name: roles/firebase.sdkProvisioningServiceAgent
+stage: GA
+title: Firebase SDK Provisioning Service Agent
+---
+description: Read-only access to Firebase products.
+etag: AA==
+name: roles/firebase.viewer
+stage: GA
+title: Firebase Viewer
+---
+description: Full read/write access to Firebase A/B Testing resources.
+etag: AA==
+name: roles/firebaseabt.admin
+stage: BETA
+title: Firebase A/B Testing Admin
+---
+description: Read-only access to Firebase A/B Testing resources.
+etag: AA==
+name: roles/firebaseabt.viewer
+stage: BETA
+title: Firebase A/B Testing Viewer
+---
+description: Full management of Firebase App Check.
+etag: AA==
+name: roles/firebaseappcheck.admin
+stage: BETA
+title: Firebase App Check Admin
+---
+description: Read-only access for Firebase App Check.
+etag: AA==
+name: roles/firebaseappcheck.viewer
+stage: BETA
+title: Firebase App Check Viewer
+---
+description: Full read/write access to Firebase App Distribution resources.
+etag: AA==
+name: roles/firebaseappdistro.admin
+stage: BETA
+title: Firebase App Distribution Admin
+---
+description: Read-only access to Firebase App Distribution resources.
+etag: AA==
+name: roles/firebaseappdistro.viewer
+stage: BETA
+title: Firebase App Distribution Viewer
+---
+description: Full read/write access to Firebase Authentication resources.
+etag: AA==
+name: roles/firebaseauth.admin
+stage: GA
+title: Firebase Authentication Admin
+---
+description: Read-only access to Firebase Authentication resources.
+etag: AA==
+name: roles/firebaseauth.viewer
+stage: GA
+title: Firebase Authentication Viewer
+---
+description: Full read/write access to symbol mapping file resources for Firebase
+  Crash Reporting.
+etag: AA==
+name: roles/firebasecrash.symbolMappingsAdmin
+stage: GA
+title: Firebase Crash Symbol Uploader
+---
+description: Full read/write access to Firebase Crashlytics resources.
+etag: AA==
+name: roles/firebasecrashlytics.admin
+stage: GA
+title: Firebase Crashlytics Admin
+---
+description: Read-only access to Firebase Crashlytics resources.
+etag: AA==
+name: roles/firebasecrashlytics.viewer
+stage: GA
+title: Firebase Crashlytics Viewer
+---
+description: Full read/write access to Firebase Realtime Database resources.
+etag: AA==
+name: roles/firebasedatabase.admin
+stage: GA
+title: Firebase Realtime Database Admin
+---
+description: Read-only access to Firebase Realtime Database resources.
+etag: AA==
+name: roles/firebasedatabase.viewer
+stage: GA
+title: Firebase Realtime Database Viewer
+---
+description: Full read/write access to Firebase Dynamic Links resources.
+etag: AA==
+name: roles/firebasedynamiclinks.admin
+stage: GA
+title: Firebase Dynamic Links Admin
+---
+description: Read-only access to Firebase Dynamic Links resources.
+etag: AA==
+name: roles/firebasedynamiclinks.viewer
+stage: GA
+title: Firebase Dynamic Links Viewer
+---
+description: Full read/write access to Firebase Hosting resources.
+etag: AA==
+name: roles/firebasehosting.admin
+stage: GA
+title: Firebase Hosting Admin
+---
+description: Read-only access to Firebase Hosting resources.
+etag: AA==
+name: roles/firebasehosting.viewer
+stage: GA
+title: Firebase Hosting Viewer
+---
+description: Full read/write access to Firebase In-App Messaging resources.
+etag: AA==
+name: roles/firebaseinappmessaging.admin
+stage: BETA
+title: Firebase In-App Messaging Admin
+---
+description: Read-only access to Firebase In-App Messaging resources.
+etag: AA==
+name: roles/firebaseinappmessaging.viewer
+stage: BETA
+title: Firebase In-App Messaging Viewer
+---
+description: Full read/write access to Firebase ML Kit resources.
+etag: AA==
+name: roles/firebaseml.admin
+stage: BETA
+title: Firebase ML Kit Admin
+---
+description: Read-only access to Firebase ML Kit resources.
+etag: AA==
+name: roles/firebaseml.viewer
+stage: BETA
+title: Firebase ML Kit Viewer
+---
+description: Grants Firebase Extensions API Service Account access to manage resources.
+etag: AA==
+name: roles/firebasemods.serviceAgent
+stage: GA
+title: Firebase Extensions API Service Agent
+---
+description: Full read/write access to Firebase Cloud Messaging resources.
+etag: AA==
+name: roles/firebasenotifications.admin
+stage: GA
+title: Firebase Cloud Messaging Admin
+---
+description: Read-only access to Firebase Cloud Messaging resources.
+etag: AA==
+name: roles/firebasenotifications.viewer
+stage: GA
+title: Firebase Cloud Messaging Viewer
+---
+description: Full access to firebaseperformance resources.
+etag: AA==
+name: roles/firebaseperformance.admin
+stage: GA
+title: Firebase Performance Reporting Admin
+---
+description: Read-only access to firebaseperformance resources.
+etag: AA==
+name: roles/firebaseperformance.viewer
+stage: GA
+title: Firebase Performance Reporting Viewer
+---
+description: Full read/write access to Firebase Predictions resources.
+etag: AA==
+name: roles/firebasepredictions.admin
+stage: GA
+title: Firebase Predictions Admin
+---
+description: Read-only access to Firebase Predictions resources.
+etag: AA==
+name: roles/firebasepredictions.viewer
+stage: GA
+title: Firebase Predictions Viewer
+---
+description: Full management of Firebase Rules.
+etag: AA==
+name: roles/firebaserules.admin
+stage: GA
+title: Firebase Rules Admin
+---
+description: Read-only access on all resources with the ability to test Rulesets.
+etag: AA==
+name: roles/firebaserules.viewer
+stage: GA
+title: Firebase Rules Viewer
+---
+description: Full management of Cloud Storage for Firebase.
+etag: AA==
+name: roles/firebasestorage.admin
+stage: BETA
+title: Cloud Storage for Firebase Admin
+---
+description: Access to Cloud Storage for Firebase through API and SDK.
+etag: AA==
+name: roles/firebasestorage.serviceAgent
+stage: GA
+title: Cloud Storage for Firebase Service Agent
+---
+description: Read-only access for Cloud Storage for Firebase.
+etag: AA==
+name: roles/firebasestorage.viewer
+stage: BETA
+title: Cloud Storage for Firebase Viewer
+---
+description: Gives Firestore service account access to managed resources.
+etag: AA==
+name: roles/firestore.serviceAgent
+title: Firestore Service Agent
+---
+description: Gives Cloud Firewall Insights service agent permissions to retrieve Firewall,
+  VM and route resources on user behalf.
+etag: AA==
+name: roles/firewallinsights.serviceAgent
+stage: GA
+title: Cloud Firewall Insights Service Agent
+---
+description: Grants the FleetEngine Service Account access to manage resources.
+etag: AA==
+name: roles/fleetengine.serviceAgent
+stage: GA
+title: FleetEngine Service Agent
+---
+description: Full access to Game Services API and related resources.
+etag: AA==
+name: roles/gameservices.admin
+stage: GA
+title: Game Services API Admin
+---
+description: Gives Game Services Service Account access to GCP resources.
+etag: AA==
+name: roles/gameservices.serviceAgent
+stage: GA
+title: Game Services Service Agent
+---
+description: Read-only access to Game Services API and related resources.
+etag: AA==
+name: roles/gameservices.viewer
+stage: GA
+title: Game Services API Viewer
+---
+description: Full access to genomics datasets and operations.
+etag: AA==
+name: roles/genomics.admin
+stage: GA
+title: Genomics Admin
+---
+description: Access to read and edit genomics datasets and operations.
+etag: AA==
+name: roles/genomics.editor
+stage: GA
+title: Genomics Editor
+---
+description: Full access to operate on genomics pipelines.
+etag: AA==
+name: roles/genomics.pipelinesRunner
+stage: GA
+title: Genomics Pipelines Runner
+---
+description: Gives Genomics Service Account access to compute resources. Includes
+  access to service accounts.
+etag: AA==
+name: roles/genomics.serviceAgent
+stage: GA
+title: Genomics Service Agent
+---
+description: Access to view genomics datasets and operations.
+etag: AA==
+name: roles/genomics.viewer
+stage: GA
+title: Genomics Viewer
+---
+description: Full access to GKE Hub resources.
+etag: AA==
+name: roles/gkehub.admin
+stage: GA
+title: GKE Hub Admin
+---
+description: Ability to set up GKE Connect between external clusters and Google.
+etag: AA==
+name: roles/gkehub.connect
+stage: GA
+title: GKE Connect Agent
+---
+description: Full access to Connect Gateway.
+etag: AA==
+name: roles/gkehub.gatewayAdmin
+stage: GA
+title: Connect Gateway Admin
+---
+description: Gives the GKE Hub service agent access to Cloud Platform resources.
+etag: AA==
+name: roles/gkehub.serviceAgent
+stage: GA
+title: GKE Hub Service Agent
+---
+description: Read-only access to GKE Hubs and related resources.
+etag: AA==
+name: roles/gkehub.viewer
+stage: GA
+title: GKE Hub Viewer
+---
+description: Administrator of Anthos Multi-cloud resources
+etag: AA==
+name: roles/gkemulticloud.admin
+stage: BETA
+title: Anthos Multi-cloud Admin
+---
+description: Grants the Anthos Multi-Cloud Service Account access to manage resources.
+etag: AA==
+name: roles/gkemulticloud.serviceAgent
+stage: GA
+title: Anthos Multi-Cloud Service Agent
+---
+description: Viewer of Anthos Multi-cloud resources
+etag: AA==
+name: roles/gkemulticloud.viewer
+stage: BETA
+title: Anthos Multi-cloud Viewer
+---
+description: Full access to Google Workspace Add-ons resources
+etag: AA==
+name: roles/gsuiteaddons.developer
+stage: GA
+title: Google Workspace Add-ons Developer
+---
+description: Read-only access to Google Workspace Add-ons resources
+etag: AA==
+name: roles/gsuiteaddons.reader
+stage: GA
+title: Google Workspace Add-ons Reader
+---
+description: Testing execution access to Google Workspace Add-ons resources
+etag: AA==
+name: roles/gsuiteaddons.tester
+stage: GA
+title: Google Workspace Add-ons Tester
+---
+description: Create, delete, update, read and list annotations.
+etag: AA==
+name: roles/healthcare.annotationEditor
+stage: GA
+title: Healthcare Annotation Editor
+---
+description: Read and list annotations in an Annotation store.
+etag: AA==
+name: roles/healthcare.annotationReader
+stage: GA
+title: Healthcare Annotation Reader
+---
+description: Administer Annotation stores.
+etag: AA==
+name: roles/healthcare.annotationStoreAdmin
+stage: GA
+title: Healthcare Annotation Administrator
+---
+description: List Annotation Stores in a dataset.
+etag: AA==
+name: roles/healthcare.annotationStoreViewer
+stage: GA
+title: Healthcare Annotation Store Viewer
+---
+description: Edit AttributeDefinition objects.
+etag: AA==
+name: roles/healthcare.attributeDefinitionEditor
+stage: GA
+title: Healthcare Attribute Definition Editor
+---
+description: Read AttributeDefinition objects in a consent store.
+etag: AA==
+name: roles/healthcare.attributeDefinitionReader
+stage: GA
+title: Healthcare Attribute Definition Reader
+---
+description: Administer ConsentArtifact objects.
+etag: AA==
+name: roles/healthcare.consentArtifactAdmin
+stage: GA
+title: Healthcare Consent Artifact Administrator
+---
+description: Edit ConsentArtifact objects.
+etag: AA==
+name: roles/healthcare.consentArtifactEditor
+stage: GA
+title: Healthcare Consent Artifact Editor
+---
+description: Read ConsentArtifact objects in a consent store.
+etag: AA==
+name: roles/healthcare.consentArtifactReader
+stage: GA
+title: Healthcare Consent Artifact Reader
+---
+description: Edit Consent objects.
+etag: AA==
+name: roles/healthcare.consentEditor
+stage: GA
+title: Healthcare Consent Editor
+---
+description: Read Consent objects in a consent store.
+etag: AA==
+name: roles/healthcare.consentReader
+stage: GA
+title: Healthcare Consent Reader
+---
+description: Administer Consent stores.
+etag: AA==
+name: roles/healthcare.consentStoreAdmin
+stage: GA
+title: Healthcare Consent Store Administrator
+---
+description: List Consent Stores in a dataset.
+etag: AA==
+name: roles/healthcare.consentStoreViewer
+stage: GA
+title: Healthcare Consent Store Viewer
+---
+description: Administer Healthcare Datasets.
+etag: AA==
+name: roles/healthcare.datasetAdmin
+stage: GA
+title: Healthcare Dataset Administrator
+---
+description: List the Healthcare Datasets in a project.
+etag: AA==
+name: roles/healthcare.datasetViewer
+stage: GA
+title: Healthcare Dataset Viewer
+---
+description: Edit DICOM images individually and in bulk.
+etag: AA==
+name: roles/healthcare.dicomEditor
+stage: GA
+title: Healthcare DICOM Editor
+---
+description: Administer DICOM stores.
+etag: AA==
+name: roles/healthcare.dicomStoreAdmin
+stage: GA
+title: Healthcare DICOM Store Administrator
+---
+description: List DICOM Stores in a dataset.
+etag: AA==
+name: roles/healthcare.dicomStoreViewer
+stage: GA
+title: Healthcare DICOM Store Viewer
+---
+description: Retrieve DICOM images from a DICOM store.
+etag: AA==
+name: roles/healthcare.dicomViewer
+stage: GA
+title: Healthcare DICOM Viewer
+---
+description: Create, delete, update, read and search FHIR resources.
+etag: AA==
+name: roles/healthcare.fhirResourceEditor
+stage: GA
+title: Healthcare FHIR Resource Editor
+---
+description: Read and search FHIR resources.
+etag: AA==
+name: roles/healthcare.fhirResourceReader
+stage: GA
+title: Healthcare FHIR Resource Reader
+---
+description: Administer FHIR resource stores.
+etag: AA==
+name: roles/healthcare.fhirStoreAdmin
+stage: GA
+title: Healthcare FHIR Store Administrator
+---
+description: List FHIR Stores in a dataset.
+etag: AA==
+name: roles/healthcare.fhirStoreViewer
+stage: GA
+title: Healthcare FHIR Store Viewer
+---
+description: List and read HL7v2 messages, update message labels, and publish new
+  messages.
+etag: AA==
+name: roles/healthcare.hl7V2Consumer
+stage: GA
+title: Healthcare HL7v2 Message Consumer
+---
+description: Read, write, and delete access to HL7v2 messages.
+etag: AA==
+name: roles/healthcare.hl7V2Editor
+stage: GA
+title: Healthcare HL7v2 Message Editor
+---
+description: Ingest HL7v2 messages received from a source network.
+etag: AA==
+name: roles/healthcare.hl7V2Ingest
+stage: GA
+title: Healthcare HL7v2 Message Ingest
+---
+description: Administer HL7v2 Stores.
+etag: AA==
+name: roles/healthcare.hl7V2StoreAdmin
+stage: GA
+title: Healthcare HL7v2 Store Administrator
+---
+description: View HL7v2 Stores in a dataset.
+etag: AA==
+name: roles/healthcare.hl7V2StoreViewer
+stage: GA
+title: Healthcare HL7v2 Store Viewer
+---
+description: Extract and analyze medical entities from a given text.
+etag: AA==
+name: roles/healthcare.nlpServiceViewer
+stage: BETA
+title: Healthcare NLP Service Viewer
+---
+description: Gives the Healthcare Service Account access to networks,Kubernetes engine,
+  and pubsub resources.
+etag: AA==
+name: roles/healthcare.serviceAgent
+stage: GA
+title: Healthcare Service Agent
+---
+description: Edit UserDataMapping objects.
+etag: AA==
+name: roles/healthcare.userDataMappingEditor
+stage: GA
+title: Healthcare User Data Mapping Editor
+---
+description: Read UserDataMapping objects in a consent store.
+etag: AA==
+name: roles/healthcare.userDataMappingReader
+stage: GA
+title: Healthcare User Data Mapping Reader
+---
+description: Access to administer all custom roles in the organization and the projects
+  below it.
+etag: AA==
+name: roles/iam.organizationRoleAdmin
+stage: GA
+title: Organization Role Administrator
+---
+description: Read access to all custom roles in the organization and the projects
+  below it.
+etag: AA==
+name: roles/iam.organizationRoleViewer
+stage: GA
+title: Organization Role Viewer
+---
+description: Access to administer all custom roles in the project.
+etag: AA==
+name: roles/iam.roleAdmin
+stage: GA
+title: Role Administrator
+---
+description: Read access to all custom roles in the project.
+etag: AA==
+name: roles/iam.roleViewer
+stage: GA
+title: Role Viewer
+---
+description: Security admin role, with permissions to get and set any IAM policy.
+etag: AA==
+name: roles/iam.securityAdmin
+stage: GA
+title: Security Admin
+---
+description: Security reviewer role, with permissions to get any IAM policy.
+etag: AA==
+name: roles/iam.securityReviewer
+stage: GA
+title: Security Reviewer
+---
+description: Create and manage service accounts.
+etag: AA==
+name: roles/iam.serviceAccountAdmin
+stage: GA
+title: Service Account Admin
+---
+description: Access to create service accounts.
+etag: AA==
+name: roles/iam.serviceAccountCreator
+stage: GA
+title: Create Service Accounts
+---
+description: Access to delete service accounts.
+etag: AA==
+name: roles/iam.serviceAccountDeleter
+stage: GA
+title: Delete Service Accounts
+---
+description: Create and manage (and rotate) service account keys.
+etag: AA==
+name: roles/iam.serviceAccountKeyAdmin
+stage: GA
+title: Service Account Key Admin
+---
+description: Impersonate service accounts (create OAuth2 access tokens, sign blobs
+  or JWTs, etc).
+etag: AA==
+name: roles/iam.serviceAccountTokenCreator
+stage: GA
+title: Service Account Token Creator
+---
+description: Run operations as the service account.
+etag: AA==
+name: roles/iam.serviceAccountUser
+stage: GA
+title: Service Account User
+---
+description: Full rights to create and manage workload identity pools.
+etag: AA==
+name: roles/iam.workloadIdentityPoolAdmin
+stage: BETA
+title: IAM Workload Identity Pool Admin
+---
+description: Read access to workload identity pools.
+etag: AA==
+name: roles/iam.workloadIdentityPoolViewer
+stage: BETA
+title: IAM Workload Identity Pool Viewer
+---
+description: Impersonate service accounts from GKE Workloads
+etag: AA==
+name: roles/iam.workloadIdentityUser
+stage: GA
+title: Workload Identity User
+---
+description: Administrator of IAP Permissions
+etag: AA==
+name: roles/iap.admin
+stage: GA
+title: IAP Policy Admin
+---
+description: Access HTTPS resources which use Identity-Aware Proxy
+etag: AA==
+name: roles/iap.httpsResourceAccessor
+stage: GA
+title: IAP-secured Web App User
+---
+description: Administrator of IAP Settings.
+etag: AA==
+name: roles/iap.settingsAdmin
+stage: GA
+title: IAP Settings Admin
+---
+description: Access Tunnel resources which use Identity-Aware Proxy
+etag: AA==
+name: roles/iap.tunnelResourceAccessor
+stage: GA
+title: IAP-secured Tunnel User
+---
+description: Full access to Identity Platform resources.
+etag: AA==
+name: roles/identityplatform.admin
+stage: BETA
+title: Identity Platform Admin
+---
+description: Read access to Identity Platform resources.
+etag: AA==
+name: roles/identityplatform.viewer
+stage: BETA
+title: Identity Platform Viewer
+---
+description: Full access to Identity Toolkit resources.
+etag: AA==
+name: roles/identitytoolkit.admin
+stage: GA
+title: Identity Toolkit Admin
+---
+description: Read access to Identity Toolkit resources.
+etag: AA==
+name: roles/identitytoolkit.viewer
+stage: GA
+title: Identity Toolkit Viewer
+---
+description: A user that has full access to all Apigee integrations.
+etag: AA==
+name: roles/integrations.apigeeIntegrationAdminRole
+stage: BETA
+title: Apigee Integration Admin
+---
+description: A developer that can deploy/undeploy Apigee integrations to the integration
+  runtime.
+etag: AA==
+name: roles/integrations.apigeeIntegrationDeployerRole
+stage: BETA
+title: Apigee Integration Deployer
+---
+description: A developer that can list, create and update Apigee integrations.
+etag: AA==
+name: roles/integrations.apigeeIntegrationEditorRole
+stage: BETA
+title: Apigee Integration Editor
+---
+description: A role that can invoke Apigee integrations.
+etag: AA==
+name: roles/integrations.apigeeIntegrationInvokerRole
+stage: BETA
+title: Apigee Integration Invoker
+---
+description: A developer that can list and view Apigee integrations.
+etag: AA==
+name: roles/integrations.apigeeIntegrationsViewer
+stage: BETA
+title: Apigee Integration Viewer
+---
+description: A role that can approve / reject Apigee integrations that contain a suspension/wait
+  task.
+etag: AA==
+name: roles/integrations.apigeeSuspensionResolver
+stage: BETA
+title: Apigee Integration Approver
+---
+description: Service account role used to setup authentication for the control plane
+  used by KubeRun Events.
+etag: AA==
+name: roles/kuberun.eventsControlPlaneServiceAgent
+stage: GA
+title: KubeRun Events Control Plane Service Agent
+---
+description: Service account role used to setup authentication for the data plane
+  used by KubeRun Events.
+etag: AA==
+name: roles/kuberun.eventsDataPlaneServiceAgent
+stage: GA
+title: KubeRun Events Data Plane Service Agent
+---
+description: Full control of Cloud Life Sciences resources.
+etag: AA==
+name: roles/lifesciences.admin
+stage: BETA
+title: Cloud Life Sciences Admin
+---
+description: Access to read and edit Cloud Life Sciences resources.
+etag: AA==
+name: roles/lifesciences.editor
+stage: BETA
+title: Cloud Life Sciences Editor
+---
+description: Gives Cloud Life Sciences Service Account access to compute resources.
+  Includes access to service accounts.
+etag: AA==
+name: roles/lifesciences.serviceAgent
+stage: GA
+title: Cloud Life Sciences Service Agent
+---
+description: Access to read Cloud Life Sciences resources.
+etag: AA==
+name: roles/lifesciences.viewer
+stage: BETA
+title: Cloud Life Sciences Viewer
+---
+description: Full access to operate on Cloud Life Sciences workflows.
+etag: AA==
+name: roles/lifesciences.workflowsRunner
+stage: BETA
+title: Cloud Life Sciences Workflows Runner
+---
+description: Access to all logging permissions, and dependent permissions.
+etag: AA==
+name: roles/logging.admin
+stage: GA
+title: Logging Admin
+---
+description: Ability to write logs to a log bucket.
+etag: AA==
+name: roles/logging.bucketWriter
+stage: GA
+title: Logs Bucket Writer
+---
+description: Access to configure log exporting and metrics.
+etag: AA==
+name: roles/logging.configWriter
+stage: GA
+title: Logs Configuration Writer
+---
+description: Ability to read restricted fields in a log bucket.
+etag: AA==
+name: roles/logging.fieldAccessor
+stage: BETA
+title: Log Field Accessor
+---
+description: Access to write logs.
+etag: AA==
+name: roles/logging.logWriter
+stage: GA
+title: Logs Writer
+---
+description: Access to view all logs, including logs with private contents.
+etag: AA==
+name: roles/logging.privateLogViewer
+stage: GA
+title: Private Logs Viewer
+---
+description: Grants a Cloud Logging Service Account the ability to create Datasets
+  and manage BigQuery Authorized Views inside those Datasets.
+etag: AA==
+name: roles/logging.serviceAgent
+stage: GA
+title: Cloud Logging Service Agent
+---
+description: Ability to read logs in a view.
+etag: AA==
+name: roles/logging.viewAccessor
+stage: GA
+title: Logs View Accessor
+---
+description: Access to view logs, except for logs with private contents.
+etag: AA==
+name: roles/logging.viewer
+stage: GA
+title: Logs Viewer
+---
+description: Full access to Google Cloud Managed Identities Domains and related resources.
+  Intended to be granted on a project-level.
+etag: AA==
+name: roles/managedidentities.admin
+stage: GA
+title: Google Cloud Managed Identities Admin
+---
+description: Read-Update-Delete to Google Cloud Managed Identities Domains and related
+  resources. Intended to be granted on a resource (domain) level.
+etag: AA==
+name: roles/managedidentities.domainAdmin
+stage: GA
+title: Google Cloud Managed Identities Domain Admin
+---
+description: Gives Managed Identities service account access to managed resources.
+etag: AA==
+name: roles/managedidentities.serviceAgent
+stage: GA
+title: Cloud Managed Identities Service Agent
+---
+description: Read-only access to Google Cloud Managed Identities Domains and related
+  resources.
+etag: AA==
+name: roles/managedidentities.viewer
+stage: GA
+title: Google Cloud Managed Identities Viewer
+---
+description: Downloads and uploads media files from and to customer GCS buckets.
+etag: AA==
+name: roles/mediaasset.serviceAgent
+stage: GA
+title: Media Asset Service Agent
+---
+description: Full access to Memcached instances and related resources.
+etag: AA==
+name: roles/memcache.admin
+stage: GA
+title: Cloud Memorystore Memcached Admin
+---
+description: Read-Write access to Memcached instances and related resources.
+etag: AA==
+name: roles/memcache.editor
+stage: GA
+title: Cloud Memorystore Memcached Editor
+---
+description: Gives Cloud Memorystore Memcached service account access to managed resource
+etag: AA==
+name: roles/memcache.serviceAgent
+stage: GA
+title: Cloud Memorystore Memcached Service Agent
+---
+description: Read-only access to Memcached instances and related resources.
+etag: AA==
+name: roles/memcache.viewer
+stage: GA
+title: Cloud Memorystore Memcached Viewer
+---
+description: Apply mesh configuration
+etag: AA==
+name: roles/meshconfig.serviceAgent
+stage: GA
+title: Mesh Config Service Agent
+---
+description: Run user-space Istio components
+etag: AA==
+name: roles/meshdataplane.serviceAgent
+stage: GA
+title: Mesh Data Plane Service Agent
+---
+description: Full access to all Dataproc Metastore resources.
+etag: AA==
+name: roles/metastore.admin
+stage: GA
+title: Dataproc Metastore Admin
+---
+description: Read and write access to all Dataproc Metastore resources.
+etag: AA==
+name: roles/metastore.editor
+stage: GA
+title: Dataproc Metastore Editor
+---
+description: Read-only access to Dataproc Metastore resources with additional metadata
+  operations permission.
+etag: AA==
+name: roles/metastore.metadataOperator
+stage: GA
+title: Dataproc Metastore Metadata Operator
+---
+description: Gives the Dataproc Metastore service account access to managed resources.
+etag: AA==
+name: roles/metastore.serviceAgent
+stage: GA
+title: Dataproc Metastore Service Agent
+---
+description: Read-only access to all Dataproc Metastore resources.
+etag: AA==
+name: roles/metastore.user
+stage: GA
+title: Dataproc Metastore Viewer
+---
+description: Full access to Cloud ML Engine.
+etag: AA==
+name: roles/ml.admin
+stage: GA
+title: ML Engine Admin
+---
+description: Access to create training and prediction jobs, models and versions, send
+  online prediction requests.
+etag: AA==
+name: roles/ml.developer
+stage: GA
+title: ML Engine Developer
+---
+description: Full access to the job.
+etag: AA==
+name: roles/ml.jobOwner
+stage: GA
+title: ML Engine Job Owner
+---
+description: Full access to the model and its versions.
+etag: AA==
+name: roles/ml.modelOwner
+stage: GA
+title: ML Engine Model Owner
+---
+description: Permissions to read the model and its versions, and use them for prediction.
+etag: AA==
+name: roles/ml.modelUser
+stage: GA
+title: ML Engine Model User
+---
+description: Full access to the operation.
+etag: AA==
+name: roles/ml.operationOwner
+stage: GA
+title: ML Engine Operation Owner
+---
+description: Cloud ML service agent can act as log writer, Cloud Storage admin, Artifact
+  Registry Reader, BigQuery writer, and service account access token creator.
+etag: AA==
+name: roles/ml.serviceAgent
+stage: GA
+title: Cloud ML Service Agent
+---
+description: Read-only access to Cloud ML Engine resources.
+etag: AA==
+name: roles/ml.viewer
+stage: GA
+title: ML Engine Viewer
+---
+description: All current and future monitoring permissions.
+etag: AA==
+name: roles/monitoring.admin
+stage: GA
+title: Monitoring Admin
+---
+description: Read/write access to alerting policies.
+etag: AA==
+name: roles/monitoring.alertPolicyEditor
+stage: BETA
+title: Monitoring AlertPolicy Editor
+---
+description: Read-only access to alerting policies.
+etag: AA==
+name: roles/monitoring.alertPolicyViewer
+stage: BETA
+title: Monitoring AlertPolicy Viewer
+---
+description: Read/write access to dashboard configurations.
+etag: AA==
+name: roles/monitoring.dashboardEditor
+stage: GA
+title: Monitoring Dashboard Configuration Editor
+---
+description: Read-only access to dashboard configurations.
+etag: AA==
+name: roles/monitoring.dashboardViewer
+stage: GA
+title: Monitoring Dashboard Configuration Viewer
+---
+description: Read/write access to all monitoring data and configuration.
+etag: AA==
+name: roles/monitoring.editor
+stage: GA
+title: Monitoring Editor
+---
+description: Write-only access to metrics.  This provides exactly the permissions
+  needed by the Stackdriver agent and other systems that send metrics.
+etag: AA==
+name: roles/monitoring.metricWriter
+stage: GA
+title: Monitoring Metric Writer
+---
+description: Read/write access to notification channels.
+etag: AA==
+name: roles/monitoring.notificationChannelEditor
+stage: BETA
+title: Monitoring NotificationChannel Editor
+---
+description: Read-only access to notification channels.
+etag: AA==
+name: roles/monitoring.notificationChannelViewer
+stage: BETA
+title: Monitoring NotificationChannel Viewer
+---
+description: Grants permissions to deliver notifications directly to resources within
+  the target project, such as delivering to Cloud PubSub topics within the project.
+etag: AA==
+name: roles/monitoring.notificationServiceAgent
+stage: GA
+title: Monitoring Notification Service Agent
+---
+description: Read/write access to services.
+etag: AA==
+name: roles/monitoring.servicesEditor
+stage: GA
+title: Monitoring Services Editor
+---
+description: Read-only access to services.
+etag: AA==
+name: roles/monitoring.servicesViewer
+stage: GA
+title: Monitoring Services Viewer
+---
+description: Read/write access to uptime check configurations.
+etag: AA==
+name: roles/monitoring.uptimeCheckConfigEditor
+stage: BETA
+title: Monitoring Uptime Check Configuration Editor
+---
+description: Read-only access to uptime check configurations.
+etag: AA==
+name: roles/monitoring.uptimeCheckConfigViewer
+stage: BETA
+title: Monitoring Uptime Check Configuration Viewer
+---
+description: Read-only access to get and list information about all monitoring data
+  and configuration.
+etag: AA==
+name: roles/monitoring.viewer
+stage: GA
+title: Monitoring Viewer
+---
+description: Gives the Multi Cluster Ingress service agent access to CloudPlatform
+  resources.
+etag: AA==
+name: roles/multiclusteringress.serviceAgent
+stage: GA
+title: Multi Cluster Ingress Service Agent
+---
+description: Gives the Multi-cluster metering service agent access to CloudPlatform
+  resources.
+etag: AA==
+name: roles/multiclustermetering.serviceAgent
+stage: GA
+title: Multi-cluster metering Service Agent
+---
+description: This role is managed by NetApp, not Google.
+etag: AA==
+name: roles/netappcloudvolumes.admin
+stage: BETA
+title: NetApp Cloud Volumes Admin
+---
+description: This role is managed by NetApp, not Google.
+etag: AA==
+name: roles/netappcloudvolumes.viewer
+stage: BETA
+title: NetApp Cloud Volumes Viewer
+---
+description: Full access to Hub and Spoke resources.
+etag: AA==
+name: roles/networkconnectivity.hubAdmin
+stage: BETA
+title: Hub & Spoke Admin
+---
+description: Read-only access to Hub and Spoke resources.
+etag: AA==
+name: roles/networkconnectivity.hubViewer
+stage: BETA
+title: Hub & Spoke Viewer
+---
+description: Create Spokes and attach them to an existing Hub.
+etag: AA==
+name: roles/networkconnectivity.spokeAdmin
+stage: BETA
+title: Spoke Admin
+---
+description: Full access to Network Management resources.
+etag: AA==
+name: roles/networkmanagement.admin
+stage: GA
+title: Network Management Admin
+---
+description: Grants the GCP Network Management API the authority to complete analysis
+  based on network configurations from Compute Engine and Container Engine.
+etag: AA==
+name: roles/networkmanagement.serviceAgent
+stage: GA
+title: GCP Network Management Service Agent
+---
+description: Read-only access to Network Management resources.
+etag: AA==
+name: roles/networkmanagement.viewer
+stage: GA
+title: Network Management Viewer
+---
+description: Full access to Notebooks all resources.
+etag: AA==
+name: roles/notebooks.admin
+stage: GA
+title: Notebooks Admin
+---
+description: Full access to Notebooks all resources through compute API.
+etag: AA==
+name: roles/notebooks.legacyAdmin
+stage: GA
+title: Notebooks Legacy Admin
+---
+description: Read-only access to Notebooks all resources through compute API.
+etag: AA==
+name: roles/notebooks.legacyViewer
+stage: GA
+title: Notebooks Legacy Viewer
+---
+description: Restricted access for running scheduled Notebooks.
+etag: AA==
+name: roles/notebooks.runner
+stage: GA
+title: Notebooks Runner
+---
+description: Provide access for notebooks service agent to manage notebook instances
+  in user projects
+etag: AA==
+name: roles/notebooks.serviceAgent
+stage: GA
+title: AI Platform Notebooks Service Agent
+---
+description: Read-only access to Notebooks all resources.
+etag: AA==
+name: roles/notebooks.viewer
+stage: GA
+title: Notebooks Viewer
+---
+description: Read/write access to OAuth config resources
+etag: AA==
+name: roles/oauthconfig.editor
+stage: BETA
+title: OAuth Config Editor
+---
+description: Read-only access to OAuth config resources
+etag: AA==
+name: roles/oauthconfig.viewer
+stage: BETA
+title: OAuth Config Viewer
+---
+description: All permissions for On-Demand Scanning
+etag: AA==
+name: roles/ondemandscanning.admin
+stage: BETA
+title: On-Demand Scanning Admin
+---
+description: Read-only access to resource metadata.
+etag: AA==
+name: roles/opsconfigmonitoring.resourceMetadata.viewer
+stage: BETA
+title: Ops Config Monitoring Resource Metadata Viewer
+---
+description: Write-only access to resource metadata. This provides exactly the permissions
+  needed by the Ops Config Monitoring metadata agent and other systems that send metadata.
+etag: AA==
+name: roles/opsconfigmonitoring.resourceMetadata.writer
+stage: BETA
+title: Ops Config Monitoring Resource Metadata Writer
+---
+description: The permission to set Organization Policies on resources.
+etag: AA==
+name: roles/orgpolicy.policyAdmin
+stage: GA
+title: Organization Policy Administrator
+---
+description: Access to view Organization Policies on resources.
+etag: AA==
+name: roles/orgpolicy.policyViewer
+stage: GA
+title: Organization Policy Viewer
+---
+description: Full admin access to GuestPolicies
+etag: AA==
+name: roles/osconfig.guestPolicyAdmin
+stage: BETA
+title: GuestPolicy Admin
+---
+description: Editor of GuestPolicy resources
+etag: AA==
+name: roles/osconfig.guestPolicyEditor
+stage: BETA
+title: GuestPolicy Editor
+---
+description: Viewer of GuestPolicy resources
+etag: AA==
+name: roles/osconfig.guestPolicyViewer
+stage: BETA
+title: GuestPolicy Viewer
+---
+description: Viewer of OS Policies Compliance of VM instances
+etag: AA==
+name: roles/osconfig.instanceOSPoliciesComplianceViewer
+stage: BETA
+title: InstanceOSPoliciesCompliance Viewer
+---
+description: Viewer of OS Inventories
+etag: AA==
+name: roles/osconfig.inventoryViewer
+stage: BETA
+title: OS Inventory Viewer
+---
+description: Full admin access to OS Policy Assignments
+etag: AA==
+name: roles/osconfig.osPolicyAssignmentAdmin
+stage: BETA
+title: OSPolicyAssignment Admin
+---
+description: Editor of OS Policy Assignments
+etag: AA==
+name: roles/osconfig.osPolicyAssignmentEditor
+stage: BETA
+title: OSPolicyAssignment Editor
+---
+description: Viewer of OS Policy Assignments
+etag: AA==
+name: roles/osconfig.osPolicyAssignmentViewer
+stage: BETA
+title: OSPolicyAssignment Viewer
+---
+description: Full admin access to PatchDeployments
+etag: AA==
+name: roles/osconfig.patchDeploymentAdmin
+stage: GA
+title: PatchDeployment Admin
+---
+description: Viewer of PatchDeployment resources
+etag: AA==
+name: roles/osconfig.patchDeploymentViewer
+stage: GA
+title: PatchDeployment Viewer
+---
+description: Access to execute Patch Jobs.
+etag: AA==
+name: roles/osconfig.patchJobExecutor
+stage: GA
+title: Patch Job Executor
+---
+description: Get and list Patch Jobs.
+etag: AA==
+name: roles/osconfig.patchJobViewer
+stage: GA
+title: Patch Job Viewer
+---
+description: Grants OS Config Service Account access to Google Compute Engine instances.
+etag: AA==
+name: roles/osconfig.serviceAgent
+stage: GA
+title: Cloud OS Config Service Agent
+---
+description: Viewer of OS VulnerabilityReports
+etag: AA==
+name: roles/osconfig.vulnerabilityReportViewer
+stage: BETA
+title: OS VulnerabilityReport Viewer
+---
+description: Full access to all resources.
+etag: AA==
+name: roles/owner
+stage: GA
+title: Owner
+---
+description: Full access to all Payments reseller subscription resource features
+etag: AA==
+name: roles/paymentsresellersubscription.partnerAdmin
+stage: BETA
+title: Payments Reseller Subscriptions Admin
+---
+description: Read access to all Payments Reseller Subscription resource features
+etag: AA==
+name: roles/paymentsresellersubscription.partnerViewer
+stage: BETA
+title: Payments Reseller Subscriptions Admin
+---
+description: Read access to Payments Reseller Product resource
+etag: AA==
+name: roles/paymentsresellersubscription.productViewer
+stage: BETA
+title: Payments Reseller Subscriptions Viewer
+---
+description: Read access to Payments Reseller Promotion resource
+etag: AA==
+name: roles/paymentsresellersubscription.promotionViewer
+stage: BETA
+title: Payments Reseller Subscriptions Viewer
+---
+description: Write access to Payments Reseller Subscription resource
+etag: AA==
+name: roles/paymentsresellersubscription.subscriptionEditor
+stage: BETA
+title: Payments Reseller Subscriptions Editor
+---
+description: Read access to Payments Reseller Subscription resource
+etag: AA==
+name: roles/paymentsresellersubscription.subscriptionViewer
+stage: BETA
+title: Payments Reseller Subscriptions Viewer
+---
+description: Admin user that can run and access replays.
+etag: AA==
+name: roles/policysimulator.admin
+stage: BETA
+title: Simulator Admin
+---
+description: Full access to all CA Service resources.
+etag: AA==
+name: roles/privateca.admin
+stage: GA
+title: CA Service Admin
+---
+description: Read-only access to all CA Service resources.
+etag: AA==
+name: roles/privateca.auditor
+stage: GA
+title: CA Service Auditor
+---
+description: Create and manage CAs, revoke certificates, create certificates templates,
+  and read-only access for CA Service resources.
+etag: AA==
+name: roles/privateca.caManager
+stage: GA
+title: CA Service Operation Manager
+---
+description: Create certificates and read-only access for CA Service resources.
+etag: AA==
+name: roles/privateca.certificateManager
+stage: GA
+title: CA Service Certificate Manager
+---
+description: Request certificates from CA Service.
+etag: AA==
+name: roles/privateca.certificateRequester
+stage: GA
+title: CA Service Certificate Requester
+---
+description: Read, list and use certificate templates.
+etag: AA==
+name: roles/privateca.templateUser
+stage: GA
+title: CA Service Certificate Template User
+---
+description: Request certificates from CA Service with caller's identity.
+etag: AA==
+name: roles/privateca.workloadCertificateRequester
+stage: GA
+title: CA Service Workload Certificate Requester
+---
+description: Can create and delete attachments; can list and get a project's beacons;
+  can list a project's namespaces.
+etag: AA==
+name: roles/proximitybeacon.attachmentEditor
+stage: GA
+title: Beacon Attachment Editor
+---
+description: Grants necessary permissions to use beacons to create attachments in
+  namespaces not owned by this project.
+etag: AA==
+name: roles/proximitybeacon.attachmentPublisher
+stage: GA
+title: Beacon Attachment Publisher
+---
+description: Can view all attachments under a namespace; no beacon or namespace permissions.
+etag: AA==
+name: roles/proximitybeacon.attachmentViewer
+stage: GA
+title: Beacon Attachment Viewer
+---
+description: Necessary access to register, modify, and view beacons; no attachment
+  or namespace permissions.
+etag: AA==
+name: roles/proximitybeacon.beaconEditor
+stage: GA
+title: Beacon Editor
+---
+description: Full access to topics, subscriptions, and snapshots.
+etag: AA==
+name: roles/pubsub.admin
+stage: GA
+title: Pub/Sub Admin
+---
+description: Modify topics and subscriptions, publish and consume messages.
+etag: AA==
+name: roles/pubsub.editor
+stage: GA
+title: Pub/Sub Editor
+---
+description: Publish messages to a topic.
+etag: AA==
+name: roles/pubsub.publisher
+stage: GA
+title: Pub/Sub Publisher
+---
+description: Grants Cloud Pub/Sub Service Account access to manage resources.
+etag: AA==
+name: roles/pubsub.serviceAgent
+stage: GA
+title: Cloud Pub/Sub Service Agent
+---
+description: Consume messages from a subscription, attach subscriptions to a topic,
+  and seek to a snapshot.
+etag: AA==
+name: roles/pubsub.subscriber
+stage: GA
+title: Pub/Sub Subscriber
+---
+description: View topics, subscriptions, and snapshots.
+etag: AA==
+name: roles/pubsub.viewer
+stage: GA
+title: Pub/Sub Viewer
+---
+description: Full access to topics, subscriptions and reservations.
+etag: AA==
+name: roles/pubsublite.admin
+stage: GA
+title: Pub/Sub Lite Admin
+---
+description: Modify topics, subscriptions and reservations, publish and consume messages.
+etag: AA==
+name: roles/pubsublite.editor
+stage: GA
+title: Pub/Sub Lite Editor
+---
+description: Publish messages to a topic.
+etag: AA==
+name: roles/pubsublite.publisher
+stage: GA
+title: Pub/Sub Lite Publisher
+---
+description: Subscribe to and read messages from a topic.
+etag: AA==
+name: roles/pubsublite.subscriber
+stage: GA
+title: Pub/Sub Lite Subscriber
+---
+description: View topics, subscriptions and reservations.
+etag: AA==
+name: roles/pubsublite.viewer
+stage: GA
+title: Pub/Sub Lite Viewer
+---
+description: Access to view and modify reCAPTCHA Enterprise keys
+etag: AA==
+name: roles/recaptchaenterprise.admin
+stage: BETA
+title: reCAPTCHA Enterprise Admin
+---
+description: Access to create and annotate reCAPTCHA Enterprise assessments
+etag: AA==
+name: roles/recaptchaenterprise.agent
+stage: BETA
+title: reCAPTCHA Enterprise Agent
+---
+description: Access to view reCAPTCHA Enterprise keys and metrics
+etag: AA==
+name: roles/recaptchaenterprise.viewer
+stage: BETA
+title: reCAPTCHA Enterprise Viewer
+---
+description: Admin of Billing Account Usage Commitment Recommender.
+etag: AA==
+name: roles/recommender.billingAccountCudAdmin
+stage: BETA
+title: Billing Account Usage Commitment Recommender Admin
+---
+description: Viewer of Billing Account Usage Commitment Recommender.
+etag: AA==
+name: roles/recommender.billingAccountCudViewer
+stage: BETA
+title: Billing Account Usage Commitment Recommender Viewer
+---
+description: Admin of all Cloud Asset insights.
+etag: AA==
+name: roles/recommender.cloudAssetInsightsAdmin
+stage: GA
+title: Cloud Asset Insights Admin
+---
+description: Viewer of all Cloud Asset insights.
+etag: AA==
+name: roles/recommender.cloudAssetInsightsViewer
+stage: GA
+title: Cloud Asset Insights Viewer
+---
+description: Admin of Cloud SQL insights and recommendations.
+etag: AA==
+name: roles/recommender.cloudsqlAdmin
+stage: BETA
+title: Cloud SQL Recommender Admin
+---
+description: Viewer of Cloud SQL insights and recommendations.
+etag: AA==
+name: roles/recommender.cloudsqlViewer
+stage: BETA
+title: Cloud SQL Recommender Viewer
+---
+description: Admin of compute recommendations.
+etag: AA==
+name: roles/recommender.computeAdmin
+stage: GA
+title: Compute Recommender Admin
+---
+description: Viewer of compute recommendations.
+etag: AA==
+name: roles/recommender.computeViewer
+stage: GA
+title: Compute Recommender Viewer
+---
+description: Admin of Firewall insights and recommendations.
+etag: AA==
+name: roles/recommender.firewallAdmin
+stage: GA
+title: Firewall Recommender Admin
+---
+description: Viewer of Firewall insights and recommendations.
+etag: AA==
+name: roles/recommender.firewallViewer
+stage: GA
+title: Firewall Recommender Viewer
+---
+description: Admin of IAM recommendations.
+etag: AA==
+name: roles/recommender.iamAdmin
+stage: GA
+title: IAM Recommender Admin
+---
+description: Viewer of IAM recommendations.
+etag: AA==
+name: roles/recommender.iamViewer
+stage: GA
+title: IAM Recommender Viewer
+---
+description: Admin of all Product Suggestion insights and recommendations.
+etag: AA==
+name: roles/recommender.productSuggestionAdmin
+stage: BETA
+title: Product Suggestion Recommenders Admin
+---
+description: Viewer of all Product Suggestion insights and recommendations.
+etag: AA==
+name: roles/recommender.productSuggestionViewer
+stage: BETA
+title: Product Suggestion Recommenders Viewer
+---
+description: Admin of Project Usage Commitment Recommender.
+etag: AA==
+name: roles/recommender.projectCudAdmin
+stage: BETA
+title: Project Usage Commitment Recommender Admin
+---
+description: Viewer of Project Usage Commitment Recommender.
+etag: AA==
+name: roles/recommender.projectCudViewer
+stage: BETA
+title: Project Usage Commitment Recommender Viewer
+---
+description: Admin of Project Utilization insights and recommendations.
+etag: AA==
+name: roles/recommender.projectUtilAdmin
+title: Project Utilization Recommender Admin
+---
+description: Viewer of Project Utilization insights and recommendations.
+etag: AA==
+name: roles/recommender.projectUtilViewer
+title: Project Utilization Recommender Viewer
+---
+description: Full access to Redis instances and related resources.
+etag: AA==
+name: roles/redis.admin
+stage: BETA
+title: Cloud Memorystore Redis Admin
+---
+description: Read-Write access to Redis instances and related resources.
+etag: AA==
+name: roles/redis.editor
+stage: BETA
+title: Cloud Memorystore Redis Editor
+---
+description: Gives Cloud Memorystore Redis service account access to managed resource
+etag: AA==
+name: roles/redis.serviceAgent
+stage: GA
+title: Cloud Memorystore Redis Service Agent
+---
+description: Read-only access to Redis instances and related resources.
+etag: AA==
+name: roles/redis.viewer
+stage: BETA
+title: Cloud Memorystore Redis Viewer
+---
+description: This role is managed by Redis Labs, not Google.
+etag: AA==
+name: roles/redisenterprisecloud.admin
+stage: BETA
+title: Redis Enterprise Cloud Admin
+---
+description: This role is managed by Redis Labs, not Google.
+etag: AA==
+name: roles/redisenterprisecloud.viewer
+stage: BETA
+title: Redis Enterprise Cloud Viewer
+---
+description: Remote Build Execution Action Cache Writer
+etag: AA==
+name: roles/remotebuildexecution.actionCacheWriter
+stage: BETA
+title: Remote Build Execution Action Cache Writer
+---
+description: Remote Build Execution Artifact Admin
+etag: AA==
+name: roles/remotebuildexecution.artifactAdmin
+stage: BETA
+title: Remote Build Execution Artifact Admin
+---
+description: Remote Build Execution Artifact Creator
+etag: AA==
+name: roles/remotebuildexecution.artifactCreator
+stage: BETA
+title: Remote Build Execution Artifact Creator
+---
+description: Remote Build Execution Artifact Viewer
+etag: AA==
+name: roles/remotebuildexecution.artifactViewer
+stage: BETA
+title: Remote Build Execution Artifact Viewer
+---
+description: Remote Build Execution Configuration Admin
+etag: AA==
+name: roles/remotebuildexecution.configurationAdmin
+stage: BETA
+title: Remote Build Execution Configuration Admin
+---
+description: Remote Build Execution Configuration Viewer
+etag: AA==
+name: roles/remotebuildexecution.configurationViewer
+stage: BETA
+title: Remote Build Execution Configuration Viewer
+---
+description: Remote Build Execution Logstream Writer
+etag: AA==
+name: roles/remotebuildexecution.logstreamWriter
+stage: BETA
+title: Remote Build Execution Logstream Writer
+---
+description: Remote Build Execution Reservation Admin
+etag: AA==
+name: roles/remotebuildexecution.reservationAdmin
+stage: BETA
+title: Remote Build Execution Reservation Admin
+---
+description: Gives Remote Build Execution service account access to managed resources.
+etag: AA==
+name: roles/remotebuildexecution.serviceAgent
+stage: GA
+title: Remote Build Execution Service Agent
+---
+description: Remote Build Execution Worker
+etag: AA==
+name: roles/remotebuildexecution.worker
+stage: BETA
+title: Remote Build Execution Worker
+---
+description: Access and administer a folder and all of its sub-resources.
+etag: AA==
+name: roles/resourcemanager.folderAdmin
+stage: GA
+title: Folder Admin
+---
+description: Create folder and view all of its sub-resources.
+etag: AA==
+name: roles/resourcemanager.folderCreator
+stage: GA
+title: Folder Creator
+---
+description: Edit, delete, and undelete a folder and all of its child resources.
+etag: AA==
+name: roles/resourcemanager.folderEditor
+stage: GA
+title: Folder Editor
+---
+description: Access and administer a folder IAM policies.
+etag: AA==
+name: roles/resourcemanager.folderIamAdmin
+stage: GA
+title: Folder IAM Admin
+---
+description: Move a folder and all of its child resources.
+etag: AA==
+name: roles/resourcemanager.folderMover
+stage: GA
+title: Folder Mover
+---
+description: Access to view a folder and all of its child resources.
+etag: AA==
+name: roles/resourcemanager.folderViewer
+stage: GA
+title: Folder Viewer
+---
+description: Access to modify Liens on projects.
+etag: AA==
+name: roles/resourcemanager.lienModifier
+stage: GA
+title: Project Lien Modifier
+---
+description: Access to administer all resources belonging to the organization.
+etag: AA==
+name: roles/resourcemanager.organizationAdmin
+stage: GA
+title: Organization Administrator
+---
+description: Access only to view an Organization.
+etag: AA==
+name: roles/resourcemanager.organizationViewer
+stage: GA
+title: Organization Viewer
+---
+description: Access to create new GCP projects.
+etag: AA==
+name: roles/resourcemanager.projectCreator
+stage: GA
+title: Project Creator
+---
+description: Access to delete GCP projects.
+etag: AA==
+name: roles/resourcemanager.projectDeleter
+stage: GA
+title: Project Deleter
+---
+description: Access and administer a project IAM policies.
+etag: AA==
+name: roles/resourcemanager.projectIamAdmin
+stage: GA
+title: Project IAM Admin
+---
+description: Access to update and move a project
+etag: AA==
+name: roles/resourcemanager.projectMover
+stage: GA
+title: Project Mover
+---
+description: Access to create, delete, update, and manage access to Tags
+etag: AA==
+name: roles/resourcemanager.tagAdmin
+stage: BETA
+title: Tag Administrator
+---
+description: Access to list Tags and manage their associations with resources
+etag: AA==
+name: roles/resourcemanager.tagUser
+stage: BETA
+title: Tag User
+---
+description: Access to list Tags and their associations with resources
+etag: AA==
+name: roles/resourcemanager.tagViewer
+stage: BETA
+title: Tag Viewer
+---
+description: Provides admin capabilities to set Resource Setting Values on resources.
+etag: AA==
+name: roles/resourcesettings.admin
+stage: GA
+title: Resource Settings Administrator
+---
+description: Provides capabilities to view Resource Settings and Resource Setting
+  Values on resources.
+etag: AA==
+name: roles/resourcesettings.viewer
+stage: GA
+title: Resource Settings Viewer
+---
+description: Full access to Retail api resources.
+etag: AA==
+name: roles/retail.admin
+stage: GA
+title: Retail Admin
+---
+description: Full access to Retail api resources except purge, rejoin, and setSponsorship.
+etag: AA==
+name: roles/retail.editor
+stage: GA
+title: Retail Editor
+---
+description: Retail service uploads product feeds and user events from Cloud Storage
+  and BigQuery, reports results to the customer Cloud Storage bucket, writes logs
+  to customer projects, and writes and reads Stackdriver metrics for customer projects.
+etag: AA==
+name: roles/retail.serviceAgent
+stage: GA
+title: Retail Service Agent
+---
+description: Grants access to read all resources in Retail.
+etag: AA==
+name: roles/retail.viewer
+stage: GA
+title: Retail Viewer
+---
+description: Full control over all Cloud Run resources.
+etag: AA==
+name: roles/run.admin
+stage: GA
+title: Cloud Run Admin
+---
+description: Read and write access to all Cloud Run resources.
+etag: AA==
+name: roles/run.developer
+stage: GA
+title: Cloud Run Developer
+---
+description: Can invoke a Cloud Run service.
+etag: AA==
+name: roles/run.invoker
+stage: GA
+title: Cloud Run Invoker
+---
+description: Gives Cloud Run service account access to managed resources.
+etag: AA==
+name: roles/run.serviceAgent
+stage: GA
+title: Cloud Run Service Agent
+---
+description: Can view the state of all Cloud Run resources, including IAM policies.
+etag: AA==
+name: roles/run.viewer
+stage: GA
+title: Cloud Run Viewer
+---
+description: Full access to RuntimeConfig resources.
+etag: AA==
+name: roles/runtimeconfig.admin
+stage: GA
+title: Cloud RuntimeConfig Admin
+---
+description: Full access to administer Secret Manager resources.
+etag: AA==
+name: roles/secretmanager.admin
+stage: GA
+title: Secret Manager Admin
+---
+description: Allows accessing the payload of secrets.
+etag: AA==
+name: roles/secretmanager.secretAccessor
+stage: GA
+title: Secret Manager Secret Accessor
+---
+description: Allows adding versions to existing secrets.
+etag: AA==
+name: roles/secretmanager.secretVersionAdder
+stage: GA
+title: Secret Manager Secret Version Adder
+---
+description: Allows creating and managing versions of existing secrets.
+etag: AA==
+name: roles/secretmanager.secretVersionManager
+stage: GA
+title: Secret Manager Secret Version Manager
+---
+description: Allows viewing metadata of all Secret Manager resources
+etag: AA==
+name: roles/secretmanager.viewer
+stage: GA
+title: Secret Manager Viewer
+---
+description: Grants Secured Landing Zone service account permissions to manage resources
+  in the customer project
+etag: AA==
+name: roles/securedlandingzone.serviceAgent
+stage: GA
+title: Secured Landing Zone Service Agent
+---
+description: Admin(super user) access to security center
+etag: AA==
+name: roles/securitycenter.admin
+stage: GA
+title: Security Center Admin
+---
+description: Admin Read-write access to security center
+etag: AA==
+name: roles/securitycenter.adminEditor
+stage: GA
+title: Security Center Admin Editor
+---
+description: Admin Read access to security center
+etag: AA==
+name: roles/securitycenter.adminViewer
+stage: GA
+title: Security Center Admin Viewer
+---
+description: Write access to asset security marks
+etag: AA==
+name: roles/securitycenter.assetSecurityMarksWriter
+stage: GA
+title: Security Center Asset Security Marks Writer
+---
+description: Run asset discovery access to assets
+etag: AA==
+name: roles/securitycenter.assetsDiscoveryRunner
+stage: GA
+title: Security Center Assets Discovery Runner
+---
+description: Read access to assets
+etag: AA==
+name: roles/securitycenter.assetsViewer
+stage: GA
+title: Security Center Assets Viewer
+---
+description: Security Center automation service agent can configure GCP resources
+  to enable security scanning.
+etag: AA==
+name: roles/securitycenter.automationServiceAgent
+stage: GA
+title: Security Center Automation Service Agent
+---
+description: Security Center Control service agent can monitor and configure GCP resources
+  and import security findings.
+etag: AA==
+name: roles/securitycenter.controlServiceAgent
+stage: GA
+title: Security Center Control Service Agent
+---
+description: Write access to finding security marks
+etag: AA==
+name: roles/securitycenter.findingSecurityMarksWriter
+stage: GA
+title: Security Center Finding Security Marks Writer
+---
+description: Read-write access to findings
+etag: AA==
+name: roles/securitycenter.findingsEditor
+stage: GA
+title: Security Center Findings Editor
+---
+description: Set state access to findings
+etag: AA==
+name: roles/securitycenter.findingsStateSetter
+stage: GA
+title: Security Center Findings State Setter
+---
+description: Read access to findings
+etag: AA==
+name: roles/securitycenter.findingsViewer
+stage: GA
+title: Security Center Findings Viewer
+---
+description: Set workflow state access to findings
+etag: AA==
+name: roles/securitycenter.findingsWorkflowStateSetter
+stage: BETA
+title: Security Center Findings Workflow State Setter
+---
+description: Write access to notification configurations
+etag: AA==
+name: roles/securitycenter.notificationConfigEditor
+stage: GA
+title: Security Center Notification Configurations Editor
+---
+description: Read access to notification configurations
+etag: AA==
+name: roles/securitycenter.notificationConfigViewer
+stage: GA
+title: Security Center Notification Configurations Viewer
+---
+description: Security Center service agent can publish notifications to Pub/Sub topics.
+etag: AA==
+name: roles/securitycenter.notificationServiceAgent
+stage: GA
+title: Security Center Notification Service Agent
+---
+description: Security Health Analytics service agent can scan GCP resource metadata
+  to find security vulnerabilities.
+etag: AA==
+name: roles/securitycenter.securityHealthAnalyticsServiceAgent
+stage: GA
+title: Security Health Analytics Service Agent
+---
+description: Security Center service agent can scan GCP resources and import security
+  scans.
+etag: AA==
+name: roles/securitycenter.serviceAgent
+stage: GA
+title: Security Center Service Agent
+---
+description: Admin(super user) access to security center settings
+etag: AA==
+name: roles/securitycenter.settingsAdmin
+stage: GA
+title: Security Center Settings Admin
+---
+description: Read-Write access to security center settings
+etag: AA==
+name: roles/securitycenter.settingsEditor
+stage: GA
+title: Security Center Settings Editor
+---
+description: Read access to security center settings
+etag: AA==
+name: roles/securitycenter.settingsViewer
+stage: GA
+title: Security Center Settings Viewer
+---
+description: Admin access to sources
+etag: AA==
+name: roles/securitycenter.sourcesAdmin
+stage: GA
+title: Security Center Sources Admin
+---
+description: Read-write access to sources
+etag: AA==
+name: roles/securitycenter.sourcesEditor
+stage: GA
+title: Security Center Sources Editor
+---
+description: Read access to sources
+etag: AA==
+name: roles/securitycenter.sourcesViewer
+stage: GA
+title: Security Center Sources Viewer
+---
+description: Gives Cloud Run service account access to managed resources.
+etag: AA==
+name: roles/serverless.serviceAgent
+stage: GA
+title: Cloud Run Service Agent
+---
+description: Full access to ServiceBroker resources.
+etag: AA==
+name: roles/servicebroker.admin
+stage: DEPRECATED
+title: Service Broker Admin
+---
+description: Operational access to the ServiceBroker resources.
+etag: AA==
+name: roles/servicebroker.operator
+stage: DEPRECATED
+title: Service Broker Operator
+---
+description: Administrate tenancy units
+etag: AA==
+name: roles/serviceconsumermanagement.tenancyUnitsAdmin
+stage: BETA
+title: Admin of Tenancy Units
+---
+description: View tenancy units
+etag: AA==
+name: roles/serviceconsumermanagement.tenancyUnitsViewer
+stage: BETA
+title: Viewer of Tenancy Units
+---
+description: Full control of all Service Directory resources and permissions.
+etag: AA==
+name: roles/servicedirectory.admin
+stage: GA
+title: Service Directory Admin
+---
+description: Edit Service Directory resources.
+etag: AA==
+name: roles/servicedirectory.editor
+stage: GA
+title: Service Directory Editor
+---
+description: Gives access to VPC Networks via Service Directory
+etag: AA==
+name: roles/servicedirectory.pscAuthorizedService
+stage: GA
+title: Private Service Connect Authorized Service
+---
+description: View Service Directory resources.
+etag: AA==
+name: roles/servicedirectory.viewer
+stage: GA
+title: Service Directory Viewer
+---
+description: Full control of Google Service Management resources.
+etag: AA==
+name: roles/servicemanagement.admin
+stage: GA
+title: Service Management Administrator
+---
+description: Access to update the service config and create rollouts.
+etag: AA==
+name: roles/servicemanagement.configEditor
+stage: GA
+title: Service Config Editor
+---
+description: Access to administer service quotas.
+etag: AA==
+name: roles/servicemanagement.quotaAdmin
+stage: BETA
+title: Quota Administrator
+---
+description: Access to view service quotas.
+etag: AA==
+name: roles/servicemanagement.quotaViewer
+stage: BETA
+title: Quota Viewer
+---
+description: Can report usage of a service during runtime.
+etag: AA==
+name: roles/servicemanagement.reporter
+stage: GA
+title: Service Reporter
+---
+description: Can enable the service.
+etag: AA==
+name: roles/servicemanagement.serviceConsumer
+stage: GA
+title: Service Consumer
+---
+description: Can check preconditions and report usage of a service during runtime.
+etag: AA==
+name: roles/servicemanagement.serviceController
+stage: GA
+title: Service Controller
+---
+description: Full control of service networking with projects.
+etag: AA==
+name: roles/servicenetworking.networksAdmin
+stage: BETA
+title: Service Networking Admin
+---
+description: Gives permission to manage network configuration, such as establishing
+  network peering, necessary for service producers
+etag: AA==
+name: roles/servicenetworking.serviceAgent
+stage: GA
+title: Service Networking Service Agent
+---
+description: Ability to create, delete, update, get and list API keys for a project.
+etag: AA==
+name: roles/serviceusage.apiKeysAdmin
+stage: GA
+title: API Keys Admin
+---
+description: Ability to get and list API keys for a project.
+etag: AA==
+name: roles/serviceusage.apiKeysViewer
+stage: GA
+title: API Keys Viewer
+---
+description: Ability to enable, disable, and inspect service states, inspect operations,
+  and consume quota and billing for a consumer project.
+etag: AA==
+name: roles/serviceusage.serviceUsageAdmin
+stage: GA
+title: Service Usage Admin
+---
+description: Ability to inspect service states and operations, and consume quota and
+  billing for a consumer project.
+etag: AA==
+name: roles/serviceusage.serviceUsageConsumer
+stage: GA
+title: Service Usage Consumer
+---
+description: Ability to inspect service states and operations for a consumer project.
+etag: AA==
+name: roles/serviceusage.serviceUsageViewer
+stage: GA
+title: Service Usage Viewer
+---
+description: Admin access to repositories
+etag: AA==
+name: roles/source.admin
+stage: GA
+title: Source Repository Administrator
+---
+description: Read access to repositories
+etag: AA==
+name: roles/source.reader
+stage: GA
+title: Source Repository Reader
+---
+description: Read / Write access to repositories
+etag: AA==
+name: roles/source.writer
+stage: GA
+title: Source Repository Writer
+---
+description: Allow Cloud Source Repositories to integrate with other Cloud services.
+etag: AA==
+name: roles/sourcerepo.serviceAgent
+stage: GA
+title: Cloud Source Repositories Service Agent
+---
+description: Full control of Cloud Spanner resources.
+etag: AA==
+name: roles/spanner.admin
+stage: GA
+title: Cloud Spanner Admin
+---
+description: Administrator role to manage Cloud Spanner backups. Does not include
+  permissions to restore from Cloud Spanner backups.
+etag: AA==
+name: roles/spanner.backupAdmin
+stage: GA
+title: Cloud Spanner Backup Admin
+---
+description: Role with limited permissions to create and manage Cloud Spanner backups.
+  Does not have permission to modify backups.
+etag: AA==
+name: roles/spanner.backupWriter
+stage: GA
+title: Cloud Spanner Backup Writer
+---
+description: Full control of Cloud Spanner databases.
+etag: AA==
+name: roles/spanner.databaseAdmin
+stage: GA
+title: Cloud Spanner Database Admin
+---
+description: Access to read and/or query a Cloud Spanner database.
+etag: AA==
+name: roles/spanner.databaseReader
+stage: GA
+title: Cloud Spanner Database Reader
+---
+description: Access to read, query, write and view and change the schema of Cloud
+  Spanner databases
+etag: AA==
+name: roles/spanner.databaseUser
+stage: GA
+title: Cloud Spanner Database User
+---
+description: Administrator role to restore Cloud Spanner databases from Cloud Spanner
+  backups.
+etag: AA==
+name: roles/spanner.restoreAdmin
+stage: GA
+title: Cloud Spanner Restore Admin
+---
+description: Viewer access to Cloud Spanner resources.
+etag: AA==
+name: roles/spanner.viewer
+stage: GA
+title: Cloud Spanner Viewer
+---
+description: Read/write access to manage Stackdriver account structure.
+etag: AA==
+name: roles/stackdriver.accounts.editor
+stage: GA
+title: Stackdriver Accounts Editor
+---
+description: Read-only access to get and list information about Stackdriver account
+  structure.
+etag: AA==
+name: roles/stackdriver.accounts.viewer
+stage: GA
+title: Stackdriver Accounts Viewer
+---
+description: Write-only access to resource metadata.  This provides exactly the permissions
+  needed by the Stackdriver metadata agent and other systems that send metadata.
+etag: AA==
+name: roles/stackdriver.resourceMetadata.writer
+stage: BETA
+title: Stackdriver Resource Metadata Writer
+---
+description: Full control of GCS resources.
+etag: AA==
+name: roles/storage.admin
+stage: GA
+title: Storage Admin
+---
+description: Full control of GCS HMAC Keys.
+etag: AA==
+name: roles/storage.hmacKeyAdmin
+stage: GA
+title: Storage HMAC Key Admin
+---
+description: Read and write access to existing buckets with object listing/creation/deletion.
+etag: AA==
+name: roles/storage.legacyBucketOwner
+stage: GA
+title: Storage Legacy Bucket Owner
+---
+description: Read access to buckets with object listing.
+etag: AA==
+name: roles/storage.legacyBucketReader
+stage: GA
+title: Storage Legacy Bucket Reader
+---
+description: Read access to buckets with object listing/creation/deletion.
+etag: AA==
+name: roles/storage.legacyBucketWriter
+stage: GA
+title: Storage Legacy Bucket Writer
+---
+description: Read/write access to existing objects without listing.
+etag: AA==
+name: roles/storage.legacyObjectOwner
+stage: GA
+title: Storage Legacy Object Owner
+---
+description: Read access to objects without listing.
+etag: AA==
+name: roles/storage.legacyObjectReader
+stage: GA
+title: Storage Legacy Object Reader
+---
+description: Full control of GCS objects.
+etag: AA==
+name: roles/storage.objectAdmin
+stage: GA
+title: Storage Object Admin
+---
+description: Access to create objects in GCS.
+etag: AA==
+name: roles/storage.objectCreator
+stage: GA
+title: Storage Object Creator
+---
+description: Read access to GCS objects.
+etag: AA==
+name: roles/storage.objectViewer
+stage: GA
+title: Storage Object Viewer
+---
+description: Create, update and manage transfer jobs and operations.
+etag: AA==
+name: roles/storagetransfer.admin
+stage: GA
+title: Storage Transfer Admin
+---
+description: Create and update storage transfer jobs and operations.
+etag: AA==
+name: roles/storagetransfer.user
+stage: GA
+title: Storage Transfer User
+---
+description: Read access to storage transfer jobs and operations.
+etag: AA==
+name: roles/storagetransfer.viewer
+stage: GA
+title: Storage Transfer Viewer
+---
+description: Access DevTools for Subscribe with Google
+etag: AA==
+name: roles/subscribewithgoogledeveloper.developer
+stage: BETA
+title: Subscribe with Google Developer
+---
+description: Read-write access to all Threat Detection settings
+etag: AA==
+name: roles/threatdetection.editor
+stage: BETA
+title: Threat Detection Settings Editor
+---
+description: Read access to all Threat Detection settings
+etag: AA==
+name: roles/threatdetection.viewer
+stage: BETA
+title: Threat Detection Settings Viewer
+---
+description: Full access to TPU nodes and related resources.
+etag: AA==
+name: roles/tpu.admin
+stage: GA
+title: TPU Admin
+---
+description: Give Cloud TPUs service account access to managed resources
+etag: AA==
+name: roles/tpu.serviceAgent
+stage: GA
+title: Cloud TPU API Service Agent
+---
+description: Read-only access to TPU nodes and related resources.
+etag: AA==
+name: roles/tpu.viewer
+stage: GA
+title: TPU Viewer
+---
+description: Traffic Director Client to fetch service configurations and report metrics
+etag: AA==
+name: roles/trafficdirector.client
+stage: BETA
+title: Traffic Director Client
+---
+description: Full access to all transcoder resources.
+etag: AA==
+name: roles/transcoder.admin
+stage: BETA
+title: Transcoder Admin
+---
+description: Downloads and uploads media files from and to customer GCS buckets. Publishes
+  status updates to customer Pub/Sub.
+etag: AA==
+name: roles/transcoder.serviceAgent
+stage: GA
+title: Transcoder Service Agent
+---
+description: Viewer of all transcoder resources.
+etag: AA==
+name: roles/transcoder.viewer
+stage: BETA
+title: Transcoder Viewer
+---
+description: Admin of Translation Hub
+etag: AA==
+name: roles/translationhub.admin
+stage: BETA
+title: Translation Hub Admin
+---
+description: Portal user of Translation Hub
+etag: AA==
+name: roles/translationhub.portalUser
+stage: BETA
+title: Translation Hub Portal User
+---
+description: Read access to all resources.
+etag: AA==
+name: roles/viewer
+stage: GA
+title: Viewer
+---
+description: Ability to view and edit all VM Migration objects
+etag: AA==
+name: roles/vmmigration.admin
+stage: BETA
+title: VM Migration Administrator
+---
+description: Ability to view all VM Migration objects
+etag: AA==
+name: roles/vmmigration.viewer
+stage: BETA
+title: VM Migration Viewer
+---
+description: Admin has full access to VMware Engine Service
+etag: AA==
+name: roles/vmwareengine.vmwareengineAdmin
+stage: GA
+title: VMware Engine Service Admin
+---
+description: Viewer has read-only access to VMware Engine Service
+etag: AA==
+name: roles/vmwareengine.vmwareengineViewer
+stage: GA
+title: VMware Engine Service Viewer
+---
+description: Full access to all Serverless VPC Access resources
+etag: AA==
+name: roles/vpcaccess.admin
+stage: GA
+title: Serverless VPC Access Admin
+---
+description: Can create and manage resources to support serverless application to
+  connect to virtual private cloud.
+etag: AA==
+name: roles/vpcaccess.serviceAgent
+stage: GA
+title: Serverless VPC Access Service Agent
+---
+description: User of Serverless VPC Access connectors
+etag: AA==
+name: roles/vpcaccess.user
+stage: GA
+title: Serverless VPC Access User
+---
+description: Viewer of all Serverless VPC Access resources
+etag: AA==
+name: roles/vpcaccess.viewer
+stage: GA
+title: Serverless VPC Access Viewer
+---
+description: Gives the Cloud Web Security Scanner service account access to compute
+  engine details and app engine details.
+etag: AA==
+name: roles/websecurityscanner.serviceAgent
+stage: GA
+title: Cloud Web Security Scanner Service Agent
+---
+description: Full access to workflows and related resources.
+etag: AA==
+name: roles/workflows.admin
+stage: GA
+title: Workflows Admin
+---
+description: Read and write access to workflows and related resources.
+etag: AA==
+name: roles/workflows.editor
+stage: GA
+title: Workflows Editor
+---
+description: Access to execute workflows and manage the executions.
+etag: AA==
+name: roles/workflows.invoker
+stage: GA
+title: Workflows Invoker
+---
+description: Gives Cloud Workflows service account access to managed resources.
+etag: AA==
+name: roles/workflows.serviceAgent
+stage: GA
+title: Cloud Workflows Service Agent
+---
+description: Read-only access to workflows and related resources.
+etag: AA==
+name: roles/workflows.viewer
+stage: GA
+title: Workflows Viewer

--- a/gcp/bootstrap/templates/backend.tpl
+++ b/gcp/bootstrap/templates/backend.tpl
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket  = "${bucket_name}"
+    prefix  = "terraform/state/${tfstate_path}"
+  }
+}

--- a/gcp/bootstrap/variables.tf
+++ b/gcp/bootstrap/variables.tf
@@ -3,7 +3,7 @@ variable "project_id" {
   description = "The ID of the project where this VPC will be created"
 }
 
-variable "project_id" {
+variable "labels" {
   type        = map(string)
   description = "Map of labels to put in resources"
   default     = {}

--- a/gcp/bootstrap/variables.tf
+++ b/gcp/bootstrap/variables.tf
@@ -1,0 +1,53 @@
+variable "project_id" {
+  type        = string
+  description = "The ID of the project where this VPC will be created"
+}
+
+variable "service_account_id" {
+  type        = string
+  description = "Service account ID to manage tfstate and provide Terraform access to orchestrate resources"
+}
+
+variable "service_account_roles" {
+  type        = list(string)
+  description = "Service account roles (gcloud iam roles list)"
+}
+
+variable "backend_name" {
+  type        = string
+  description = "Terraform backend GCS bucket name"
+}
+
+variable "backend_location" {
+  type        = string
+  description = "Terraform backend GCS bucket (use one documented here https://cloud.google.com/storage/docs/locations)"
+  default     = "US"
+}
+
+variable "kms_location" {
+  type        = string
+  description = "Terraform keyring location (use one documented here https://cloud.google.com/kms/docs/locations)"
+  default     = "us"
+}
+
+variable "key_rotation_days" {
+  type        = number
+  description = "Number of days to set automatic encryption key rotation for bucket"
+  default     = 15
+}
+
+variable "service_account_key_rotation_days" {
+  type        = number
+  description = "Number of days to set automatic key rotation for service account"
+  default     = 30
+}
+
+variable "tfstate_path" {
+  type        = string
+  description = "Remote path on GCS bucket to put terraform tfstate with remote backend"
+}
+
+variable "backend_local_path" {
+  type        = string
+  description = "Local path to create terraform backend configuration file"
+}

--- a/gcp/bootstrap/variables.tf
+++ b/gcp/bootstrap/variables.tf
@@ -3,6 +3,12 @@ variable "project_id" {
   description = "The ID of the project where this VPC will be created"
 }
 
+variable "project_id" {
+  type        = map(string)
+  description = "Map of labels to put in resources"
+  default     = {}
+}
+
 variable "service_account_id" {
   type        = string
   description = "Service account ID to manage tfstate and provide Terraform access to orchestrate resources"

--- a/gcp/bootstrap/variables.tf
+++ b/gcp/bootstrap/variables.tf
@@ -36,7 +36,7 @@ variable "kms_location" {
   default     = "us"
 }
 
-variable "key_rotation_days" {
+variable "kms_key_rotation_days" {
   type        = number
   description = "Number of days to set automatic encryption key rotation for bucket"
   default     = 15

--- a/gcp/bootstrap/versions.tf
+++ b/gcp/bootstrap/versions.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_version = ">= 0.13.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.45"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.45"
+    }
+  }
+
+  provider_meta "google" {
+    module_name = "blueprints/terraform/terraform-google-network:vpc/v3.2.2"
+  }
+
+  provider_meta "google-beta" {
+    module_name = "blueprints/terraform/terraform-google-network:vpc/v3.2.2"
+  }
+
+}

--- a/gcp/bootstrap/versions.tf
+++ b/gcp/bootstrap/versions.tf
@@ -12,12 +12,4 @@ terraform {
     }
   }
 
-  provider_meta "google" {
-    module_name = "blueprints/terraform/terraform-google-network:vpc/v3.2.2"
-  }
-
-  provider_meta "google-beta" {
-    module_name = "blueprints/terraform/terraform-google-network:vpc/v3.2.2"
-  }
-
 }


### PR DESCRIPTION
Adding GCP bootstrap module, useful to avoid any manual setup for terraform backend or service acccount.